### PR TITLE
transfer: log TransferError cause

### DIFF
--- a/src/dvc_data/transfer.py
+++ b/src/dvc_data/transfer.py
@@ -36,8 +36,7 @@ def _log_exceptions(func):
             # pylint: disable=no-member
             if isinstance(exc, OSError) and exc.errno == errno.EMFILE:
                 raise
-
-            logger.debug("failed to transfer '%s'", path)
+            logger.exception("failed to transfer '%s'", path)
             return 1
 
     return wrapper


### PR DESCRIPTION
when a transfer fails, we currently return no information about what is failing and why. This patch adds the exception name/message to the debugging log so that re-running with `-v` actually returns some meaning error about why some transfer is failing.

Related to iterative/dvc/issues/7861