### PR TITLE
stage: pass oid instead of hash_info to odb.add in stage_external

### DIFF
--- a/src/dvc_data/stage.py
+++ b/src/dvc_data/stage.py
@@ -76,6 +76,7 @@ def _stage_file(path, fs, name, odb=None, upload_odb=None, dry_run=False):
     else:
         odb.add(path, fs, oid, hardlink=False)
         obj = odb.get(oid)
+        obj.hash_info = hash_info
 
     return path, meta, obj
 


### PR DESCRIPTION
There are test failures in https://github.com/iterative/dvc-s3/runs/6872482318?check_suite_focus=true#step:8:114 and https://github.com/iterative/dvc-hdfs/runs/6872483982?check_suite_focus=true#step:8:168.

There are two issues: 
1. Use of `hash_info` instead of `oid`. This is fixed by 21cca9ba4.
2. The `odb.get` uses `odb.hash_name` instead of external objects' hash_name (i.e. uses `md5` instead of `etag` for example in s3). I have fixed this by resetting to original value in dc5009215 (I know this is wrong way to fix it, and requires proper fix in dvc-objects, but I was not sure how to).

Anyway, with both of this issue, external imports and external add is broken.