### PR TITLE
hash_info: don't use dataclass

### DIFF
--- a/src/dvc_data/hashfile/hash_info.py
+++ b/src/dvc_data/hashfile/hash_info.py
@@ -1,35 +1,47 @@
 from collections import OrderedDict
-from dataclasses import dataclass, field
 from typing import Optional
 
 HASH_DIR_SUFFIX = ".dir"
 
 
-@dataclass
 class HashInfo:
-    name: Optional[str]
-    value: Optional[str]
-    obj_name: Optional[str] = field(default=None, compare=False)
+    __slots__ = ("name", "value", "obj_name")
 
-    def __bool__(self):
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        value: Optional[str] = None,
+        obj_name: Optional[str] = None,
+    ):
+        self.name = name
+        self.value = value
+        self.obj_name = obj_name
+
+    def __eq__(self, other):
+        if not isinstance(other, HashInfo):
+            return False
+
+        return (self.name == other.name) and (self.value == other.value)
+
+    def __bool__(self) -> bool:
         return bool(self.value)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.name}: {self.value}"
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.name, self.value))
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, d) -> "HashInfo":
         if not d:
             return cls(None, None)
 
         ((name, value),) = d.items()
         return cls(name, value)
 
-    def to_dict(self):
-        ret = OrderedDict()
+    def to_dict(self) -> dict:
+        ret: dict = OrderedDict()
         if not self:
             return ret
 
@@ -37,8 +49,8 @@ class HashInfo:
         return ret
 
     @property
-    def isdir(self):
-        if not self:
+    def isdir(self) -> bool:
+        if not self.value:
             return False
         return self.value.endswith(HASH_DIR_SUFFIX)
 


### PR DESCRIPTION
We are creating lots of these instances and dataclass is significantly slower.

For example, running:

```
from dvc_data.hashfile.hash_info import HashInfo


hashes = []
for value in range(10000000):
    hashes.append(HashInfo("md5", value))
```

before this PR takes ~6.1sec and after ~4.9sec.

Most of the improvement is actually coming from using `__slots__`, which were finally supported by dataclasses in 3.10.

Another (temporary) downside to using dataclass is that it is kinda buggy with other tools. E.g. `mypyc` is failing to compile it throwing an error like https://github.com/mypyc/mypyc/issues/921 for the `HashInfo.name`.
