### PR TITLE
tree: rename get -> get_obj

### DIFF
--- a/src/dvc_data/diff.py
+++ b/src/dvc_data/diff.py
@@ -101,7 +101,7 @@ def diff(
         if not obj or key == ROOT:
             return obj.hash_info if obj else None
 
-        entry_obj = obj.get(cache, key)
+        entry_obj = obj.get_obj(cache, key)
         return entry_obj.hash_info if entry_obj else None
 
     def _in_cache(oid, cache):

--- a/src/dvc_data/objects/tree.py
+++ b/src/dvc_data/objects/tree.py
@@ -195,7 +195,7 @@ class Tree(HashFile):
             pass
         return tree
 
-    def get(self, odb, prefix: Tuple[str]) -> Optional[Object]:
+    def get_obj(self, odb, prefix: Tuple[str]) -> Optional[Object]:
         """Return object at the specified prefix in this tree.
 
         Returns None if no object exists at the specified prefix.


### PR DESCRIPTION
This method is quite contraversial in itself, but lets for now just rename
it so it is out of the way.