### PR TITLE
diff: use tree.get instead of tree.get_obj

### DIFF
--- a/src/dvc_data/diff.py
+++ b/src/dvc_data/diff.py
@@ -101,8 +101,8 @@ def diff(
         if not obj or key == ROOT:
             return obj.hash_info if obj else None
 
-        entry_obj = obj.get_obj(cache, key)
-        return entry_obj.hash_info if entry_obj else None
+        _, oid = obj.get(key, (None, None))
+        return oid
 
     def _in_cache(oid, cache):
         from dvc_objects.errors import ObjectFormatError

--- a/src/dvc_data/objects/tree.py
+++ b/src/dvc_data/objects/tree.py
@@ -67,6 +67,11 @@ class Tree(HashFile):
         self.__dict__.pop("trie", None)
         self._dict[key] = (meta, oid)
 
+    def get(
+        self, key: Tuple[str, ...], default=None
+    ) -> Optional[Tuple[Optional["Meta"], "HashInfo"]]:
+        return self._dict.get(key, default)
+
     def digest(self):
         from dvc_objects.fs import MemoryFileSystem
         from dvc_objects.fs.utils import tmp_fname


### PR DESCRIPTION
Avoids creating unnecessary intermediate objects.