### PR TITLE
introduce repo concept, make plumbing CLI available as dvc-data command

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,7 @@ def lint(session: nox.Session) -> None:
     args = *(session.posargs or ("--show-diff-on-failure",)), "--all-files"
     session.run("pre-commit", "run", *args)
     session.run("python", "-m", "mypy")
-    session.run("python", "-m", "pylint", "src", "cli.py")
+    session.run("python", "-m", "pylint", "src")
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ warn_no_return = true
 warn_redundant_casts = true
 warn_unreachable = true
 ignore_missing_imports = true
-files = ["src", "tests", "cli.py"]
+files = ["src", "tests"]
 
 [tool.pylint.message_control]
 enable = ["c-extension-no-member", "no-else-return"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,10 @@ install_requires=
     nanotime>=0.5.2
 
 [options.extras_require]
+cli =
+    typer>=0.4,<0.5
+all =
+    %(cli)s
 tests =
     pytest==7.1.2
     pytest-sugar==0.9.4
@@ -45,8 +49,12 @@ tests =
     universal-pathlib==0.0.19
     s3fs[boto3]>=2022.02.0; python_version < '3.11'
 dev =
+    %(all)s
     %(tests)s
-    typer>=0.4,<0.5
+
+[options.entry_points]
+console_scripts =
+    dvc-data = dvc_data.__main__:app
 
 [options.packages.find]
 exclude =
@@ -67,4 +75,4 @@ select = B,C,E,F,W,T4,B902,T,P
 show_source = true
 count = true
 per-file-ignores =
-    cli.py:B008
+    src/dvc_data/cli.py:B008

--- a/src/dvc_data/__main__.py
+++ b/src/dvc_data/__main__.py
@@ -1,0 +1,17 @@
+try:
+    from .cli import app
+except ImportError:  # pragma: no cover
+
+    def app():  # type: ignore[misc]
+        import sys
+
+        print(
+            "dvc-data could not run because the required "
+            "dependencies are not installed.\n"
+            "Please install it with: pip install 'dvc-data[cli]'"
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/dvc_data/repo.py
+++ b/src/dvc_data/repo.py
@@ -1,0 +1,55 @@
+import os
+
+from dvc_objects.fs import LocalFileSystem
+from dvc_objects.fs.base import FileSystem
+
+
+class NotARepo(Exception):
+    pass
+
+
+localfs = LocalFileSystem()
+
+
+class Repo:
+    def __init__(self, root: str = "", fs: FileSystem = None) -> None:
+        fs = fs or localfs
+        root = root or fs.path.getcwd()
+        control_dir: str = os.getenv("DVC_DIR") or fs.path.join(root, ".dvc")
+
+        if not fs.isdir(control_dir):
+            raise NotARepo(f"{root} is not a data repo.")
+
+        self.fs = fs or localfs
+        self.root = root
+        self._control_dir = control_dir
+        self._tmp_dir: str = fs.path.join(self._control_dir, "tmp")
+        self._object_dir: str = fs.path.join(self._control_dir, "cache")
+
+    @classmethod
+    def discover(
+        cls,
+        start: str = ".",
+        fs: FileSystem = None,
+    ) -> "Repo":
+        remaining = True
+        fs = fs or localfs
+        path = start = fs.path.abspath(start)
+        while remaining:
+            try:
+                return cls(path, fs)
+            except NotARepo:
+                path, remaining = fs.path.split(path)
+        raise NotARepo(f"No data repository was found at {start}")
+
+    @property
+    def control_dir(self):
+        return self._control_dir
+
+    @property
+    def tmp_dir(self):
+        return self._tmp_dir
+
+    @property
+    def object_dir(self):
+        return self._object_dir


### PR DESCRIPTION
We need to introduce repo concept so that the plumbing CLI command
is compatible with `dvc init` created repositories.

CLi command will try to discover `.dvc` directory. You can alternatively specify `DVC_DIR` envvar in which case it'll consider your current working directory as root and will use `DVC_DIR` as an object_dir and tmp directory for state. 

This change makes it compatible with dvc-created repositories.