### PR TITLE
lazy state flush

### DIFF
--- a/src/dvc_data/cli.py
+++ b/src/dvc_data/cli.py
@@ -207,7 +207,7 @@ def build(
     lazy_state: bool = False,
 ):
     odb = get_odb(no_state=no_state)
-    fs_path = relpath(path)
+    fs_path = os.fspath(path)
 
     fs = odb.fs
     if fs_path == "-":

--- a/src/dvc_data/hashfile/cache.py
+++ b/src/dvc_data/hashfile/cache.py
@@ -1,5 +1,6 @@
 import os
 import pickle
+import time
 from functools import wraps
 from typing import Any
 
@@ -9,6 +10,7 @@ from diskcache import Index  # noqa: F401, pylint: disable=unused-import
 from diskcache import Timeout  # noqa: F401, pylint: disable=unused-import
 
 # pylint: disable=redefined-builtin
+from funcy import print_durations
 
 
 class DiskError(Exception):
@@ -63,3 +65,98 @@ class Cache(diskcache.Cache):
 
     def __getstate__(self):
         return (*super().__getstate__(), self._type)
+
+    def set(self, key, value, expire=None, read=False, tag=None, retry=False):
+        """Set `key` and `value` item in cache.
+
+        When `read` is `True`, `value` should be a file-like object opened
+        for reading in binary mode.
+
+        Raises :exc:`Timeout` error when database timeout occurs and `retry` is
+        `False` (default).
+
+        :param key: key for item
+        :param value: value for item
+        :param float expire: seconds until item expires
+            (default None, no expiry)
+        :param bool read: read value as bytes from file (default False)
+        :param str tag: text to associate with key (default None)
+        :param bool retry: retry if database timeout occurs (default False)
+        :return: True if item was set
+        :raises Timeout: if database timeout occurs
+
+        """
+        now = time.time()
+        db_key, raw = self._disk.put(key)
+        expire_time = None if expire is None else now + expire
+        size, mode, filename, db_value = self._disk.store(value, read, key=key)
+        with self._transact(retry, filename) as (sql, _cleanup):
+            sql(
+                "INSERT OR REPLACE INTO Cache("
+                " key, raw, store_time, expire_time, access_time,"
+                " access_count, tag, size, mode, filename, value"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    db_key,
+                    raw,
+                    now,  # store_time
+                    expire_time,
+                    now,  # access_time
+                    0,  # access_count
+                    tag,
+                    size,
+                    mode,
+                    filename,
+                    db_value,
+                ),
+            )
+
+    @print_durations
+    def set_many(self, d, expire=None, read=False, tag=None, retry=False):
+        """Set `key` and `value` item in cache.
+
+        When `read` is `True`, `value` should be a file-like object opened
+        for reading in binary mode.
+
+        Raises :exc:`Timeout` error when database timeout occurs and `retry` is
+        `False` (default).
+
+        :param key: key for item
+        :param value: value for item
+        :param float expire: seconds until item expires
+            (default None, no expiry)
+        :param bool read: read value as bytes from file (default False)
+        :param str tag: text to associate with key (default None)
+        :param bool retry: retry if database timeout occurs (default False)
+        :return: True if item was set
+        :raises Timeout: if database timeout occurs
+
+        """
+        now = time.time()
+        expire_time = None if expire is None else now + expire
+
+        with self._transact(retry) as (sql, _cleanup):
+            for (key, value) in d:
+                db_key, raw = self._disk.put(key)
+                size, mode, filename, db_value = self._disk.store(
+                    value, read, key=key
+                )
+                sql(
+                    "INSERT OR REPLACE INTO Cache("
+                    " key, raw, store_time, expire_time, access_time,"
+                    " access_count, tag, size, mode, filename, value"
+                    ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        db_key,
+                        raw,
+                        now,  # store_time
+                        expire_time,
+                        now,  # access_time
+                        0,  # access_count
+                        tag,
+                        size,
+                        mode,
+                        filename,
+                        db_value,
+                    ),
+                )

--- a/src/dvc_data/hashfile/state.py
+++ b/src/dvc_data/hashfile/state.py
@@ -94,9 +94,11 @@ class State(StateBase):  # pylint: disable=too-many-instance-attributes
         self.in_mem_hashes.clear()
         yield
 
-        with self.hashes.transact():
-            for path, entry in self.in_mem_hashes.items():
-                self.hashes[path] = json.dumps(entry)
+        it = (
+            (path, json.dumps(entry))
+            for path, entry in self.in_mem_hashes.items()
+        )
+        self.hashes.set_many(it)
         self.in_mem_hashes.clear()
         self._lazy_flush.reset(tok)
 


### PR DESCRIPTION
This is not a serious PR, I have opened it so that we can see the performance diff between without state and with state.

### Benchmark

The benchmark is done on mnist dataset with following behaviours/changes:
1. Default (empty state) -> _4.277 kobj/s on average_
```console
$ time dvc-data build dataset 
object e42412b82dcab425ce9c7e2d0abdfb78.dir
dvc-data build dataset  11.49s user 3.09s system 89% cpu 16.368 total
```

2. `--no-state` (i.e. does not use any state) -> _20 kobj/s on average_
```console
$ time dvc-data build dataset --no-state
object e42412b82dcab425ce9c7e2d0abdfb78.dir
dvc-data build dataset --no-state  3.07s user 0.53s system 99% cpu 3.614 total
```

3.  `--lazy-state` (i.e. updating state at the very end which this PR does) -> _7.563 kobj/s_
```
$ time dvc-data build dataset --lazy-state
object e42412b82dcab425ce9c7e2d0abdfb78.dir
dvc-data build dataset --lazy-state  7.76s user 1.40s system 98% cpu 9.256 total
```

4. Fully filled state, default -> _29.166 kobj/s_
```
$ time dvc-data build dataset             
object e42412b82dcab425ce9c7e2d0abdfb78.dir
dvc-data build dataset  2.12s user 0.27s system 99% cpu 2.400 total
```

We can drop this further by reducing `fs.info`/`fs.size` and `fs.checksum` calls, which results in following results:
1. Default (empty state)  14.955s (4.680 kobj/s)
2. `--no-state` 2.906s (24.088 kobj/s)
3. `--lazy-state` 8.101s (8.641 kobj/s)
4. Fully filled state (no change)

The performance diff between the `--no-state` and the default is 5.15x.