### PR TITLE
tree: fix incorrect trie attr to be _trie

### DIFF
--- a/src/dvc_data/cli.py
+++ b/src/dvc_data/cli.py
@@ -412,7 +412,7 @@ def apply_op(odb, obj, application):
         return
     if op == "remove":
         obj._dict.pop(keys)
-        obj.__dict__.pop("trie", None)
+        obj.__dict__.pop("_trie", None)
         return
     if op in ("copy", "move"):
         new = tuple(application["to"].split("/"))

--- a/src/dvc_data/objects/tree.py
+++ b/src/dvc_data/objects/tree.py
@@ -64,7 +64,7 @@ class Tree(HashFile):
     def add(
         self, key: Tuple[str, ...], meta: Optional["Meta"], oid: "HashInfo"
     ):
-        self.__dict__.pop("trie", None)
+        self.__dict__.pop("_trie", None)
         self._dict[key] = (meta, oid)
 
     def get(


### PR DESCRIPTION
The cached_property, `Tree._trie` should be invalidated in a couple of places, but it's referenced as `trie` instead of `_trie`, so it doesn't get removed. For example, we can run this:
```python
from dvc_data.objects.tree import Tree
obj = Tree()
obj._trie
obj.add(('a',), None, 'a')
print(len(obj), len(obj._trie))
```
Currently, we get:
```
1 0
```
After this fix, we correctly get:
```
1 1
```

For an alternative where the trie is actually updated instead of removed, see: https://github.com/iterative/dvc-data/pull/102