### PR TITLE
tree: update trie instead of removing it

### DIFF
--- a/src/dvc_data/cli.py
+++ b/src/dvc_data/cli.py
@@ -412,7 +412,9 @@ def apply_op(odb, obj, application):
         return
     if op == "remove":
         obj._dict.pop(keys)
-        obj.__dict__.pop("trie", None)
+        trie = obj.__dict__.get("_trie")
+        if trie is not None:
+            trie.pop(keys)
         return
     if op in ("copy", "move"):
         new = tuple(application["to"].split("/"))

--- a/src/dvc_data/objects/tree.py
+++ b/src/dvc_data/objects/tree.py
@@ -64,7 +64,9 @@ class Tree(HashFile):
     def add(
         self, key: Tuple[str, ...], meta: Optional["Meta"], oid: "HashInfo"
     ):
-        self.__dict__.pop("trie", None)
+        trie = self.__dict__.get("_trie")
+        if trie is not None:
+            trie.update([(key, (meta, oid))])
         self._dict[key] = (meta, oid)
 
     def get(


### PR DESCRIPTION
Instead of removing the `Tree._trie` cached property and having to re-construct the entire trie, maybe the trie should just be updated alongside `Tree._dict`.

This would make this PR unnecessary: https://github.com/iterative/dvc-data/pull/101