### PR TITLE
building tree: batch save/get from state

### DIFF
--- a/dataset.dvc
+++ b/dataset.dvc
@@ -1,0 +1,3 @@
+outs:
+  - md5: e42412b82dcab425ce9c7e2d0abdfb78.dir
+    path: dataset


### PR DESCRIPTION
Tests pending. See https://github.com/iterative/dvc-data/pull/93 for previous attempts/work.

### Building objects

#### Before
```console
$ time dvc-data build mnist
object e42412b82dcab425ce9c7e2d0abdfb78.dir                                                                                    
dvc-data build mnist  12.54s user 3.62s system 90% cpu 17.907 total
$ time dvc-data build mnist
object e42412b82dcab425ce9c7e2d0abdfb78.dir                                                                                    
dvc-data build mnist  2.27s user 0.25s system 99% cpu 2.542 total
```

### After
```console
$ time dvc-data build mnist
object e42412b82dcab425ce9c7e2d0abdfb78.dir                                                                                    
dvc-data build mnist  5.08s user 0.65s system 98% cpu 5.820 total
$ time dvc-data build mnist
object e42412b82dcab425ce9c7e2d0abdfb78.dir                                                                                    
dvc-data build mnist  1.16s user 0.15s system 98% cpu 1.318 total
```

### `data status`
#### Before
```console
$ time dvc data status
DVC committed changes:                                                                                                         
  (git commit the corresponding dvc files to update the repo)
        added: mnist/
(there are other changes not tracked by dvc, use "git status" to see)
dvc data status  12.41s user 3.57s system 89% cpu 17.863 total
$ time dvc data status
DVC committed changes:                                                                                                         
  (git commit the corresponding dvc files to update the repo)
        added: mnist/
(there are other changes not tracked by dvc, use "git status" to see)
dvc data status  2.79s user 0.23s system 99% cpu 3.035 total
```

#### After
```console
$ time dvc data status
DVC committed changes:                                                                                                         
  (git commit the corresponding dvc files to update the repo)
        added: mnist/
(there are other changes not tracked by dvc, use "git status" to see)
dvc data status  7.53s user 1.01s system 98% cpu 8.638 total
$ time dvc data status
DVC committed changes:                                                                                                         
  (git commit the corresponding dvc files to update the repo)
        added: mnist/
(there are other changes not tracked by dvc, use "git status" to see)
dvc data status  1.94s user 0.21s system 99% cpu 2.169 total
```


The improvements are coming from [`set_many`](https://github.com/iterative/dvc-data/blob/a4aa927c5dc74344b63d7c491289b9cf7ebe3693/src/dvc_data/hashfile/cache.py#L84) where we save hashes in a transaction and in one `executemany`, and [`get_many`](https://github.com/iterative/dvc-data/blob/a4aa927c5dc74344b63d7c491289b9cf7ebe3693/src/dvc_data/hashfile/cache.py#L69) where we fetch multiple rows in one go (by chunking to 999 limit).

This required modifications to how we build tree, basically now we:
1. collect all files
2. compare all files path with state, to see if some paths are already hashed/unchanged and some paths are new.
3. we only hash the new files and save those hashes/checksums to the db immediately.
4. We combine both information from state and hashing to build a new tree.

This of course complicates the implementation a bit. But from what I see, building tree and a single objects are quite different that we should not try to keep them in sync, they have different requirements.