### PR TITLE
deps: bump pytest-servers to 0.0.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ tests =
     pytest-mock==3.8.2
     pylint==2.14.5
     mypy==0.961
-    pytest-servers[s3]==0.0.7
+    pytest-servers[s3]==0.0.8
 dev =
     %(all)s
     %(tests)s


### PR DESCRIPTION
fixes CI hangs