### PR TITLE
cli: add filewatcher based tree building

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ dev =
     %(all)s
     %(tests)s
     blake3>=0.3.1
+    watchfiles==0.16.1
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This uses `watchfiles` library. This is just something to play around with the concept and figure out what we need to have support for this. :)

### Usage
```console
pip install -e ".[dev]"
dvc-data watch <directory>
```