### PR TITLE
checkout: use to_fs.makedirs instead of odb.makedirs

### DIFF
--- a/src/dvc_data/checkout.py
+++ b/src/dvc_data/checkout.py
@@ -152,7 +152,8 @@ class Link:
         if to_fs.exists(to_path):
             to_fs.remove(to_path)  # broken symlink
 
-        cache.makedirs(cache.fs.path.parent(to_path))
+        parent = to_fs.path.parent(to_path)
+        to_fs.makedirs(parent)
         try:
             with Callback.as_tqdm_callback(
                 callback,


### PR DESCRIPTION
local_odb.makedirs will try to chmod, which is only required
while adding to odb. We should be using to_fs.makedirs while
checking files out.

Following the discussion in https://iterativeai.slack.com/archives/CB41NAL8H/p1659605519798349?thread_ts=1659537458.508189&cid=CB41NAL8H. 
