### PR TITLE
checkout: bulk save to state db

### DIFF
--- a/src/dvc_data/hashfile/hash_info.py
+++ b/src/dvc_data/hashfile/hash_info.py
@@ -23,6 +23,14 @@ class HashInfo:
 
         return (self.name == other.name) and (self.value == other.value)
 
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"name='{self.name}', "
+            f"value='{self.value}', "
+            f"obj_name='{self.obj_name}')"
+        )
+
     def __bool__(self) -> bool:
         return bool(self.value)
 

--- a/src/dvc_data/hashfile/meta.py
+++ b/src/dvc_data/hashfile/meta.py
@@ -23,6 +23,24 @@ class Meta:
         self.nfiles = nfiles
         self.isexec = isexec
 
+    def __eq__(self, other):
+        if not isinstance(other, Meta):
+            return False
+
+        return (
+            (self.size == other.size)
+            and (self.nfiles == other.nfiles)
+            and (self.isexec == other.isexec)
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"size={self.size}, "
+            f"nfiles={self.nfiles}, "
+            f"isexec={self.isexec})"
+        )
+
     @classmethod
     def from_dict(cls, d: dict) -> "Meta":
         if not d:

--- a/tests/hashfile/test_cache.py
+++ b/tests/hashfile/test_cache.py
@@ -47,3 +47,11 @@ def test_pickle_backwards_compat(tmp_path, proto_a, proto_b):
         assert ("value1", "value2") == cache["key"]
         set_value(cache, "key", ("value3", "value4"))
         assert ("value3", "value4") == cache["key"]
+
+
+def test_set_many(tmp_path):
+    d = {f"key{i}": f"value-{i}" for i in range(10)}
+    with Cache(directory=fspath(tmp_path / "cache")) as cache:
+        cache.set_many(d.items())
+
+    assert {key: cache[key] for key in cache} == d

--- a/tests/hashfile/test_state.py
+++ b/tests/hashfile/test_state.py
@@ -1,0 +1,26 @@
+from os import fspath
+from unittest.mock import ANY
+
+from dvc_objects.fs.implementations.local import localfs
+
+from dvc_data.hashfile.hash import hash_file
+from dvc_data.hashfile.state import State
+
+
+def test_bulk_save(tmp_path):
+    expected = {}
+    for idx in range(10):
+        fs_path = fspath(tmp_path / f"path{idx}")
+        localfs.pipe(fs_path, b"contents" + bytes(idx))
+        meta, hash_info = hash_file(fs_path, localfs, "md5")
+        meta.isexec = ANY  # we don't care about isexec
+        expected[fs_path] = meta, hash_info
+
+    state = State(tmp_path, tmp_path / "state")
+
+    with state.bulk_save(localfs) as save:
+        for path, (_, hash_info) in expected.items():
+            save(path, hash_info)
+
+    actual = {key: state.get(key, localfs) for key in state.hashes}
+    assert expected == actual


### PR DESCRIPTION
Benchmark result:
```console
---------------------------------------------------------------------------------------------- benchmark: 6 tests ---------------------------------------------------------------------------------------------
Name (time in ms)                               Min                 Max                Mean             StdDev              Median                IQR            Outliers     OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_checkout[hardlink] (0002_8583fe7)     178.07 (1.0)        185.4915 (1.0)      183.5871 (1.0)       2.9614 (1.0)      184.5672 (1.0)       2.3730 (1.0)           1;1  5.4470 (1.0)           5           1
test_checkout[symlink] (0002_8583fe7)      204.6496 (1.15)     248.2437 (1.34)     228.8035 (1.25)     18.0854 (6.11)     228.3393 (1.24)     30.2647 (12.75)         2;0  4.3706 (0.80)          5           1
test_checkout[hardlink] (0001_main)        319.6131 (1.79)     503.6169 (2.72)     3.3692 (1.98)       78.5951 (26.54)    331.1256 (1.79)     50.8841 (21.44)         1;1  2.7520 (0.51)          5           1
test_checkout[symlink] (0001_main)         370.5857 (2.08)     444.6127 (2.40)     389.6925 (2.12)     30.8932 (10.43)    378.6941 (2.05)     21.3963 (9.02)          1;1  2.5661 (0.47)          5           1
test_checkout[copy] (0002_8583fe7)         500.6298 (2.81)     553.9835 (2.99)     520.7563 (2.84)     20.8995 (7.06)     512.8228 (2.78)     26.8281 (11.31)         1;0  1.9203 (0.35)          5           1
test_checkout[copy] (0001_main)            662.2399 (3.71)     702.3355 (3.79)     681.7533 (3.71)     17.7564 (6.00)     672.7696 (3.65)     29.7173 (12.52)         2;0  1.4668 (0.27)          5           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

Testing on an mnist dataset, I get the following results:
```console
$ git checkout bulk-state-save-checkout
$ time dvc-data checkout e42412b82dcab425ce9c7e2d0abdfb78.dir dataset --type symlink
dvc-data checkout e42412b82dcab425ce9c7e2d0abdfb78.dir dataset --type symlink  6.92s user 2.62s system 99% cpu 9.606 total
$ time dvc-data checkout e42412b82dcab425ce9c7e2d0abdfb78.dir dataset --type hardlink
dvc-data checkout e42412b82dcab425ce9c7e2d0abdfb78.dir dataset --type hardlin  7.70s user 2.21s system 99% cpu 9.999 total
$ time dvc-data checkout e42412b82dcab425ce9c7e2d0abdfb78.dir dataset --type reflink
dvc-data checkout e42412b82dcab425ce9c7e2d0abdfb78.dir dataset --type reflink  7.94s user 2.94s system 98% cpu 10.996 total
$ time dvc-data checkout e42412b82dcab425ce9c7e2d0abdfb78.dir dataset --type copy    
dvc-data checkout e42412b82dcab425ce9c7e2d0abdfb78.dir dataset --type copy  57.13s user 9.11s system 99% cpu 1:06.60 total

$ git checkout main
$ time dvc-data checkout e42412b82dcab425ce9c7e2d0abdfb78.dir dataset --type symlink
dvc-data checkout e42412b82dcab425ce9c7e2d0abdfb78.dir dataset --type symlink  11.79s user 8.01s system 91% cpu 21.698 total
$ time dvc-data checkout e42412b82dcab425ce9c7e2d0abdfb78.dir dataset --type hardlink
dvc-data checkout e42412b82dcab425ce9c7e2d0abdfb78.dir dataset --type hardlin  11.88s user 7.61s system 89% cpu 21.725 total   
$ time dvc-data checkout e42412b82dcab425ce9c7e2d0abdfb78.dir dataset --type reflink 
dvc-data checkout e42412b82dcab425ce9c7e2d0abdfb78.dir dataset --type reflink  12.88s user 8.75s system 91% cpu 23.547 total                                   
$ time dvc-data checkout e42412b82dcab425ce9c7e2d0abdfb78.dir dataset --type copy   
dvc-data checkout e42412b82dcab425ce9c7e2d0abdfb78.dir dataset --type copy  67.23s user 16.49s system 94% cpu 1:28.57 total                                                                                                         