### PR TITLE
Issue with patch_file path in process_patch function

### DIFF
--- a/src/dvc_data/cli.py
+++ b/src/dvc_data/cli.py
@@ -426,7 +426,7 @@ def process_patch(patch_file, **kwargs):
                 op = appl.get("op")
                 path = appl.get("path")
                 if op and path and op in ("add", "modify"):
-                    patch[idx]["path"] = os.fspath(
+                    appl["path"] = os.fspath(
                         patch_file.parent.joinpath(path)
                     )
 

--- a/src/dvc_data/cli.py
+++ b/src/dvc_data/cli.py
@@ -418,14 +418,15 @@ def merge_tree(oid1: str, oid2: str, force: bool = False):
 def process_patch(patch_file, **kwargs):
     patch = []
     if patch_file:
+        patch_file = Path(patch_file)
         with typer.open_file(patch_file) as f:
             text = f.read()
             patch = json.loads(text)
-            for appl in patch:
+            for idx, appl in enumerate(patch):
                 op = appl.get("op")
                 path = appl.get("path")
                 if op and path and op in ("add", "modify"):
-                    patch[appl]["path"] = os.fspath(
+                    patch[idx]["path"] = os.fspath(
                         patch_file.parent.joinpath(path)
                     )
 

--- a/src/dvc_data/cli.py
+++ b/src/dvc_data/cli.py
@@ -421,7 +421,7 @@ def process_patch(patch_file, **kwargs):
         with typer.open_file(patch_file) as f:
             text = f.read()
             patch = json.loads(text)
-            for idx, appl in enumerate(patch):
+            for appl in patch:
                 op = appl.get("op")
                 path = appl.get("path")
                 if op and path and op in ("add", "modify"):

--- a/src/dvc_data/cli.py
+++ b/src/dvc_data/cli.py
@@ -431,7 +431,7 @@ def process_patch(patch_file, **kwargs):
         for item in items:
             if isinstance(item, tuple):
                 path, to = item
-                extra = {"path": path, "to": to}
+                extra = {"path": os.fspath(path), "to": to}
             else:
                 extra = {"path": item}
             patch.append({"op": op, **extra})

--- a/src/dvc_data/cli.py
+++ b/src/dvc_data/cli.py
@@ -418,7 +418,6 @@ def merge_tree(oid1: str, oid2: str, force: bool = False):
 def process_patch(patch_file, **kwargs):
     patch = []
     if patch_file:
-        patch_file = Path(patch_file)
         with typer.open_file(patch_file) as f:
             text = f.read()
             patch = json.loads(text)
@@ -426,9 +425,7 @@ def process_patch(patch_file, **kwargs):
                 op = appl.get("op")
                 path = appl.get("path")
                 if op and path and op in ("add", "modify"):
-                    appl["path"] = os.fspath(
-                        patch_file.parent.joinpath(path)
-                    )
+                    appl["path"] = os.fspath(patch_file.parent.joinpath(path))
 
     for op, items in kwargs.items():
         for item in items:
@@ -482,10 +479,21 @@ def multi_value(*opts, **kwargs):
 
 
 cl_path = click.Path(
-    exists=True, file_okay=True, dir_okay=False, readable=True
+    exists=True,
+    file_okay=True,
+    dir_okay=False,
+    readable=True,
+    path_type=Path,
+    resolve_path=True,
 )
 cl_path_dash = click.Path(
-    exists=True, file_okay=True, dir_okay=False, readable=True, allow_dash=True
+    exists=True,
+    file_okay=True,
+    dir_okay=False,
+    readable=True,
+    allow_dash=True,
+    path_type=Path,
+    resolve_path=True,
 )
 
 


### PR DESCRIPTION
Fixed `patch_file` which is expected to be a `Path` object but `click` returns a string, so it fails when trying to use the `parent` method later.

Also when modifying the path for each `appl` in the patch list there was an error while indexing the list because a string was being used instead of an integer index.