### PR TITLE
hash_info: use attrs slotted class

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires=
     dvc-objects==0.1.11
     diskcache>=5.2.1
     nanotime>=0.5.2
+    attrs>=21.3.0
 
 [options.extras_require]
 cli =


### PR DESCRIPTION
It is like `dataclasses`, and can generate slotted classes. Regarding performance, it generates class and is out of the picture when we call it. If you look into the code it generates for `__init__`, it will be identical.

```pycon
>>> from dvc_data.hashfile.hash_info import HashInfo
>>> import inspect
>>> print(inspect.getsource(HashInfo.__init__))
def __init__(self, name=attr_dict['name'].default, value=attr_dict['value'].default, obj_name=attr_dict['obj_name'].default):
    self.name = name
    self.value = value
    self.obj_name = obj_name
```

Just generating a repr is going to be ugly and tiresome. Example of what an actual implementation would look like (which is now generated for free for us):
```python
def __repr__(self) -> str:
    return f'{self.__class__.__qualname__}(name={self.name!r}, value={self.value!r}, obj_name={self.obj_name!r})'
```

### Benchmarks
#### Before
```console
pyperf timeit --rigorous  -s "from dvc_data.hashfile.hash_info import HashInfo" "HashInfo('md5', 'value.dir')"
.........................................
Mean +- std dev: 146 ns +- 4 ns
```

#### After
```console
pyperf timeit --rigorous  -s "from dvc_data.hashfile.hash_info import HashInfo" "HashInfo('md5', 'value.dir')"
.........................................
Mean +- std dev: 146 ns +- 3 ns
```

Sometimes one is faster than the others. But they generate identical code that the initialization time should be close.

I did not migrate other classes, which can be done on successive PRs. We removed 19 lines of boilerplate code here.

Let's analyze the pros and cons of this PR/proposal:

#### Pros:
- generates lots of methods for us (eg: `__init__`, `__repr__`, `__eq__`, `__hash__`) and reduces boilerplate.
- better DX (eg: generates `__repr__` for us and other dunder methods)
- same performance as slotted classes by default.

#### Cons:
- Same as `dataclasses`, the import time will increase by a few milliseconds.
- Need to depend on another package.