### PR TITLE
meta: use recurse=False in attrs.asdict

### DIFF
--- a/src/dvc_data/hashfile/meta.py
+++ b/src/dvc_data/hashfile/meta.py
@@ -27,4 +27,4 @@ class Meta:
         )
 
     def to_dict(self) -> Dict[str, Any]:
-        return asdict(self, filter=_filter_default_or_none)
+        return asdict(self, recurse=False, filter=_filter_default_or_none)


### PR DESCRIPTION
This is a micro-optimization that avoids unneccessary codepaths.

The Meta class is simple class, without having nested instances, so we don't really need `recurse`. The performance improves by 2x, but this is not where we really care about it though.

It's just something I noticed and should have been set as that when I changed this class to use `attrs`.