### PR TITLE
ci: simpler concurrency

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,7 +9,7 @@ env:
   PY_COLORS: "1"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ env:
   FORCE_COLOR: "1"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
When using previous concurrency method, whenever a release was made, running workflows for the sha in the main branch would cancel. This is not what we want, we want to only have one running workflow in a pull request but we don't want any limits on `release`/`main` branch.

Still, until further testing, I am hesitant to upstream this into py-template. Let's test this for a week.