### PR TITLE
index: separate entry odb and entry cache

### DIFF
--- a/src/dvc_data/index.py
+++ b/src/dvc_data/index.py
@@ -21,6 +21,7 @@ class DataIndexEntry:
     obj: Optional["HashFile"] = None
     hash_info: Optional["HashInfo"] = None
     odb: Optional["HashFileDB"] = None
+    cache: Optional["HashFileDB"] = None
     remote: Optional["HashFileDB"] = None
 
     loaded: Optional[bool] = None
@@ -162,7 +163,7 @@ def build(index, path, fs, **kwargs):
             del index[key:]
 
         try:
-            _, meta, obj = obuild(
+            odb, meta, obj = obuild(
                 entry.odb,
                 fs.path.join(path, *key),
                 fs,
@@ -175,6 +176,7 @@ def build(index, path, fs, **kwargs):
             obj = None
             hash_info = None
 
+        entry.odb = odb
         entry.meta = meta
         entry.obj = obj
         entry.hash_info = hash_info

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -75,8 +75,8 @@ def test_build(tmp_upath, odb, as_filesystem):
 
     index = DataIndex(
         {
-            ("foo",): DataIndexEntry(odb=odb),
-            ("data",): DataIndexEntry(odb=odb),
+            ("foo",): DataIndexEntry(odb=odb, cache=odb),
+            ("data",): DataIndexEntry(odb=odb, cache=odb),
         },
     )
     build(index, tmp_upath, as_filesystem(tmp_upath.fs))
@@ -84,7 +84,8 @@ def test_build(tmp_upath, odb, as_filesystem):
     assert (
         index[("foo",)].hash_info.value == "d3b07384d113edec49eaa6238ad5ff00"
     )
-    assert index[("foo",)].odb == odb
+    assert index[("foo",)].odb != odb
+    assert index[("foo",)].cache == odb
     assert index[("data",)].hash_info.name == "md5"
     assert (
         index[("data",)].hash_info.value


### PR DESCRIPTION
For example, think of our `dvc import`s, where `entry.odb` is that repo's
remote, but `cache` is your local repo's cache.