### PR TITLE
Add index.info() and use it in fs.info() and fs.ls()

### DIFF
--- a/src/dvc_data/fs.py
+++ b/src/dvc_data/fs.py
@@ -80,28 +80,16 @@ class DataFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
             else:
                 return [path]
 
-        self.index._ensure_loaded(root_key)  # pylint: disable=protected-access
         if not detail:
-
-            def node_factory(_, key, children, *args):
-                if key == root_key:
-                    list(children)
-                else:
-                    entries.append(self.path.join(path, key[-1]))
-
-        else:
-
-            def node_factory(_, key, children, *args):
-                if key == root_key:
-                    list(children)
-                else:
-                    epath = self.path.join(path, key[-1])
-                    info = self.index.info(key)
-                    info["name"] = epath
-                    entries.append(info)
+            return [
+                self.path.join(path, key[-1])
+                for key in self.index.ls(root_key, detail=False)
+            ]
 
         entries = []
-        self.index.traverse(node_factory, prefix=root_key)
+        for key, info in self.index.ls(root_key, detail=True):
+            info["name"] = self.path.join(path, key[-1])
+            entries.append(info)
         return entries
 
     def isdvc(self, path, recursive=False):

--- a/src/dvc_data/fs.py
+++ b/src/dvc_data/fs.py
@@ -71,11 +71,15 @@ class DataFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
         return fs.open(fspath, mode=mode, encoding=encoding)
 
     def ls(self, path, detail=True, **kwargs):
-        info = self.info(path)
-        if info["type"] != "directory":
-            return [info] if detail else [path]
-
         root_key = self._get_key(path)
+        info = self.index.info(root_key)
+        if info["type"] != "directory":
+            if detail:
+                info["name"] = path
+                return [info]
+            else:
+                return [path]
+
         try:
             entries = [
                 self.path.join(path, name) if path else name

--- a/src/dvc_data/fs.py
+++ b/src/dvc_data/fs.py
@@ -102,39 +102,10 @@ class DataFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
         return self.index.has_node(key)
 
     def info(self, path, **kwargs):
-        from dvc_data.index import ShortKeyError
-
         key = self._get_key(path)
-
-        try:
-            entry = self.index[key]
-            isdir = entry.hash_info and entry.hash_info.isdir
-            return {
-                "type": "directory" if isdir else "file",
-                "name": path,
-                "size": entry.meta.size if entry.meta else 0,
-                "isexec": entry.meta.isexec if entry.meta else False,
-                "version_id": entry.meta.version_id if entry.meta else None,
-                "isdvc": True,
-                "isout": True,
-                "obj": entry.obj,
-                "entry": entry,
-                entry.hash_info.name: entry.hash_info.value,
-            }
-        except ShortKeyError:
-            return {
-                "type": "directory",
-                "name": path,
-                "size": 0,
-                "isexec": False,
-                "version_id": None,
-                "isdvc": bool(self.index.longest_prefix(key)),
-                "isout": False,
-                "obj": None,
-                "entry": None,
-            }
-        except KeyError as exc:
-            raise FileNotFoundError from exc
+        info = self.index.info(key)
+        info["name"] = path
+        return info
 
     def get_file(  # pylint: disable=arguments-differ
         self, rpath, lpath, callback=DEFAULT_CALLBACK, **kwargs

--- a/src/dvc_data/index.py
+++ b/src/dvc_data/index.py
@@ -112,6 +112,9 @@ class DataIndex(MutableMapping):
     def longest_prefix(self, *args, **kwargs):
         return self._trie.longest_prefix(*args, **kwargs)
 
+    def traverse(self, *args, **kwargs):
+        return self._trie.traverse(*args, **kwargs)
+
     def iteritems(self, prefix=None, shallow=False):
         kwargs = {"shallow": shallow}
         if prefix:
@@ -152,11 +155,7 @@ class DataIndex(MutableMapping):
         except KeyError as exc:
             raise FileNotFoundError from exc
 
-    def ls(self, prefix=None):
-        kwargs = {}
-        if prefix:
-            kwargs["prefix"] = prefix
-
+    def _ensure_loaded(self, prefix):
         entry = self._trie.get(prefix)
         if (
             entry
@@ -167,18 +166,6 @@ class DataIndex(MutableMapping):
             self._load(prefix, entry)
             if not entry.obj:
                 raise TreeError
-
-        ret = []
-
-        def node_factory(_, key, children, *args):
-            if key == prefix:
-                list(children)
-            else:
-                ret.append(key[-1])
-
-        self._trie.traverse(node_factory, **kwargs)
-
-        return ret
 
 
 def build(index, path, fs, **kwargs):

--- a/src/dvc_data/index.py
+++ b/src/dvc_data/index.py
@@ -125,6 +125,33 @@ class DataIndex(MutableMapping):
             self._load(key, entry)
             yield key, entry
 
+    def info(self, key):
+        try:
+            entry = self[key]
+            isdir = entry.hash_info and entry.hash_info.isdir
+            return {
+                "type": "directory" if isdir else "file",
+                "size": entry.meta.size if entry.meta else 0,
+                "isexec": entry.meta.isexec if entry.meta else False,
+                "isdvc": True,
+                "isout": True,
+                "obj": entry.obj,
+                "entry": entry,
+                entry.hash_info.name: entry.hash_info.value,
+            }
+        except ShortKeyError:
+            return {
+                "type": "directory",
+                "size": 0,
+                "isexec": False,
+                "isdvc": bool(self.longest_prefix(key)),
+                "isout": False,
+                "obj": None,
+                "entry": None,
+            }
+        except KeyError as exc:
+            raise FileNotFoundError from exc
+
     def ls(self, prefix=None):
         kwargs = {}
         if prefix:

--- a/src/dvc_data/index.py
+++ b/src/dvc_data/index.py
@@ -167,6 +167,26 @@ class DataIndex(MutableMapping):
             if not entry.obj:
                 raise TreeError
 
+    def ls(self, root_key, detail=True):
+        self._ensure_loaded(root_key)
+        if not detail:
+
+            def node_factory(_, key, children, *args):
+                if key == root_key:
+                    return children
+                else:
+                    return key
+
+        else:
+
+            def node_factory(_, key, children, *args):
+                if key == root_key:
+                    return children
+                else:
+                    return key, self.info(key)
+
+        return self.traverse(node_factory, prefix=root_key)
+
 
 def build(index, path, fs, **kwargs):
     from .build import build as obuild

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -62,9 +62,14 @@ def test_fs(tmp_upath, odb, as_filesystem):
     assert fs.exists("foo")
     assert fs.cat("foo") == b"foo\n"
     assert fs.ls("/", detail=False) == ["/foo", "/data"]
+    assert fs.ls("/", detail=True) == [fs.info("/foo"), fs.info("/data")]
     assert fs.cat("/data/bar") == b"bar\n"
     assert fs.cat("/data/baz") == b"baz\n"
     assert fs.ls("/data", detail=False) == ["/data/bar", "/data/baz"]
+    assert fs.ls("/data", detail=True) == [
+        fs.info("/data/bar"),
+        fs.info("/data/baz"),
+    ]
 
 
 def test_build(tmp_upath, odb, as_filesystem):


### PR DESCRIPTION
This will allow `dvc ls` to use index.info() directly, which should improve performance. `DataFileSystem.ls(..., detail=True)` should also become faster.