### PR TITLE
checkout: basic implementation without object checkout

### DIFF
--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -45,11 +45,11 @@ class Change:
         return self.typ != UNCHANGED
 
 
-def diff(old: "DataIndex", new: "DataIndex"):
-    old_keys = {key for key, _ in old.iteritems()}
-    new_keys = {key for key, _ in new.iteritems()}
+def diff(old: Optional["DataIndex"], new: Optional["DataIndex"]):
+    old_keys = {key for key, _ in old.iteritems()} if old else set()
+    new_keys = {key for key, _ in new.iteritems()} if new else set()
 
     for key in old_keys | new_keys:
-        old_entry = old.get(key)
-        new_entry = new.get(key)
+        old_entry = old.get(key) if old else None
+        new_entry = new.get(key) if new else None
         yield Change(key, old_entry, new_entry)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -211,6 +211,7 @@ def test_checkout(tmp_upath, odb, as_filesystem):
                 ),
             ),
             ("data",): DataIndexEntry(
+                meta=Meta(isdir=True),
                 odb=odb,
                 hash_info=HashInfo(
                     name="md5",


### PR DESCRIPTION
We are not handling dirs well during collection right now, so there are some shortcuts in this implementation among other things.