### PR TITLE
index: checkout: update meta along the way

### DIFF
--- a/src/dvc_data/index/checkout.py
+++ b/src/dvc_data/index/checkout.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Optional
 
 from dvc_objects.fs.generic import transfer
 
+from ..hashfile.meta import Meta
 from .diff import ADD, DELETE, MODIFY, diff
 
 if TYPE_CHECKING:
@@ -46,3 +47,4 @@ def checkout(
             fs,
             entry_path,
         )
+        entry.meta = Meta.from_info(fs.info(entry_path))


### PR DESCRIPTION
Since checkout created new files and knows that they have particular hash, it should also update the meta. This is similar to how we do `state.save` in `hashfile.checkout`.