### PR TITLE
index: add dvc_data.index.view() and DataIndexView

### DIFF
--- a/src/dvc_data/hashfile/tree.py
+++ b/src/dvc_data/hashfile/tree.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from dvc_objects.db import ObjectDB
 
     from ..hashfile.hash_info import HashInfo
-    from ..index import DataIndex, DataIndexKey
+    from ..index import BaseDataIndex, DataIndexKey
 
 logger = logging.getLogger(__name__)
 
@@ -331,14 +331,14 @@ def merge(odb, ancestor_info, our_info, their_info, allowed=None):
 
 
 def tree_from_index(
-    index: "DataIndex",
+    index: "BaseDataIndex",
     prefix: "DataIndexKey",
 ) -> Tuple["Meta", "Tree"]:
     tree_meta = Meta(size=0, nfiles=0, isdir=True)
     assert tree_meta.size is not None and tree_meta.nfiles is not None
     tree = Tree()
     for key, entry in index.iteritems(prefix=prefix):
-        if key == prefix or entry.meta.isdir:
+        if key == prefix or entry.meta and entry.meta.isdir:
             continue
         assert entry.meta and entry.hash_info
         tree_key = key[len(prefix) :]

--- a/src/dvc_data/index/__init__.py
+++ b/src/dvc_data/index/__init__.py
@@ -8,3 +8,7 @@ from .serialize import (  # noqa: F401, pylint: disable=unused-import
     write_db,
     write_json,
 )
+from .view import (  # noqa: F401, pylint: disable=unused-import
+    DataIndexView,
+    view,
+)

--- a/src/dvc_data/index/checkout.py
+++ b/src/dvc_data/index/checkout.py
@@ -8,14 +8,14 @@ from .diff import ADD, DELETE, MODIFY, diff
 if TYPE_CHECKING:
     from dvc_objects.fs.base import FileSystem
 
-    from .index import DataIndex
+    from .index import BaseDataIndex
 
 
 def checkout(
-    index: "DataIndex",
+    index: "BaseDataIndex",
     path: str,
     fs: "FileSystem",
-    old: Optional["DataIndex"] = None,
+    old: Optional["BaseDataIndex"] = None,
     delete=False,
 ) -> None:
     delete = []

--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Optional, Tuple
 from attrs import define, field
 
 if TYPE_CHECKING:
-    from .index import DataIndex
+    from .index import BaseDataIndex
 
 from .index import DataIndexEntry
 
@@ -45,7 +45,7 @@ class Change:
         return self.typ != UNCHANGED
 
 
-def diff(old: Optional["DataIndex"], new: Optional["DataIndex"]):
+def diff(old: Optional["BaseDataIndex"], new: Optional["BaseDataIndex"]):
     old_keys = {key for key, _ in old.iteritems()} if old else set()
     new_keys = {key for key, _ in new.iteritems()} if new else set()
 

--- a/src/dvc_data/index/save.py
+++ b/src/dvc_data/index/save.py
@@ -4,10 +4,10 @@ from ..hashfile.hash_info import HashInfo
 from ..hashfile.meta import Meta
 
 if TYPE_CHECKING:
-    from .index import DataIndex, DataIndexKey
+    from .index import BaseDataIndex, DataIndexKey
 
 
-def md5(index: "DataIndex") -> None:
+def md5(index: "BaseDataIndex") -> None:
     from ..hashfile.hash import fobj_md5
 
     for _, entry in index.iteritems():
@@ -42,7 +42,9 @@ def md5(index: "DataIndex") -> None:
             )
 
 
-def _save_dir_entry(index: "DataIndex", key: "DataIndexKey", odb=None) -> None:
+def _save_dir_entry(
+    index: "BaseDataIndex", key: "DataIndexKey", odb=None
+) -> None:
     from ..hashfile.db import add_update_tree
     from ..hashfile.tree import tree_from_index
 
@@ -57,7 +59,7 @@ def _save_dir_entry(index: "DataIndex", key: "DataIndexKey", odb=None) -> None:
     setattr(entry.meta, tree.hash_info.name, tree.hash_info.value)
 
 
-def save(index: "DataIndex", odb=None) -> None:
+def save(index: "BaseDataIndex", odb=None) -> None:
     dir_entries: List["DataIndexKey"] = []
 
     for key, entry in index.iteritems():

--- a/src/dvc_data/index/save.py
+++ b/src/dvc_data/index/save.py
@@ -11,13 +11,14 @@ def md5(index: "BaseDataIndex") -> None:
     from ..hashfile.hash import fobj_md5
 
     for _, entry in index.iteritems():
-        if entry.meta.isdir:
+        assert entry.fs
+        if entry.meta and entry.meta.isdir:
             continue
 
         if entry.hash_info:
             continue
 
-        if entry.meta.version_id and entry.fs.version_aware:
+        if entry.meta and entry.meta.version_id and entry.fs.version_aware:
             # NOTE: if we have versioning available - there is no need to check
             # metadata as we can directly get correct file content using
             # version_id.
@@ -63,6 +64,7 @@ def save(index: "BaseDataIndex", odb=None) -> None:
     dir_entries: List["DataIndexKey"] = []
 
     for key, entry in index.iteritems():
+        assert entry.meta and entry.fs
         if entry.meta.isdir:
             dir_entries.append(key)
             continue
@@ -79,6 +81,8 @@ def save(index: "BaseDataIndex", odb=None) -> None:
 
         if entry.hash_info:
             cache = odb or entry.cache
+            assert entry.hash_info.value
+            assert cache
             cache.add(
                 path,
                 entry.fs,

--- a/src/dvc_data/index/view.py
+++ b/src/dvc_data/index/view.py
@@ -1,0 +1,98 @@
+from collections import deque
+from typing import Any, Callable, Iterable, Iterator, Optional, Set, Tuple
+
+from .index import BaseDataIndex, DataIndex, DataIndexEntry, DataIndexKey
+
+
+class DataIndexView(BaseDataIndex):
+    def __init__(
+        self,
+        index: DataIndex,
+        prefixes: Iterable[DataIndexKey],
+        keys: Iterable[DataIndexKey],
+    ):
+        self._index = index
+        self._prefixes = set(prefixes)
+        self._keys = set(keys)
+
+    def __getitem__(self, key: DataIndexKey) -> DataIndexEntry:
+        if key in self._keys:
+            return self._index[key]
+        raise KeyError
+
+    def __iter__(self) -> Iterator[DataIndexKey]:
+        return iter(self._keys)
+
+    def __len__(self):
+        return len(self._keys)
+
+    def iteritems(
+        self, prefix: Optional[DataIndexKey] = None, shallow: bool = False
+    ) -> Iterator[Tuple[DataIndexKey, DataIndexEntry]]:
+        if prefix is None:
+            yield from self.items()
+            return
+        if prefix in self._prefixes:
+            for key in self._index.iterkeys(prefix=prefix, shallow=shallow):
+                if key in self._keys:
+                    yield key, self._index[key]
+
+    def traverse(self, node_factory: Callable, **kwargs) -> Any:
+        def _node_factory(path_conv, key, children, *args):
+            if not key or key in self._keys or key in self._prefixes:
+                return node_factory(path_conv, key, children, *args)
+
+        return self._index.traverse(_node_factory, **kwargs)
+
+    def has_node(self, key: DataIndexKey) -> bool:
+        return key in self._keys or key in self._prefixes
+
+    def longest_prefix(
+        self, key: DataIndexKey
+    ) -> Tuple[Optional[DataIndexKey], Optional[DataIndexEntry]]:
+        if key in self._keys:
+            return self._index.longest_prefix(key)
+        return (None, None)
+
+
+def _view_keys(
+    index: DataIndex, filter_fn: Callable[[DataIndexKey], bool]
+) -> Tuple[Set[DataIndexKey], Set[DataIndexKey]]:
+    """Return (prefixes, keys) matching the specified filter."""
+
+    class _FilterNode:
+        def __init__(self, key, children):
+            self.key = key
+            self.children = children
+
+        def build(self, stack):
+            for child in self.children:
+                stack.append(child)
+            return self.key, bool(self.children)
+
+    def node_factory(_, key, children, *args) -> Optional[_FilterNode]:
+        if not key or filter_fn(key):
+            return _FilterNode(key, children)
+        return None
+
+    prefixes: Set[DataIndexKey] = set()
+    keys: Set[DataIndexKey] = set()
+    stack = deque([index.traverse(node_factory)])
+    while stack:
+        node = stack.popleft()
+        if node is not None:
+            key, is_prefix = node.build(stack)
+            if key:
+                if is_prefix:
+                    prefixes.add(key)
+                else:
+                    keys.add(key)
+    return prefixes, keys
+
+
+def view(
+    index: DataIndex, filter_fn: Callable[[DataIndexKey], bool]
+) -> DataIndexView:
+    """Return read-only filtered view of an index."""
+    prefixes, keys = _view_keys(index, filter_fn)
+    return DataIndexView(index, prefixes, keys)


### PR DESCRIPTION
Provides read-only view into DataIndex using a filtered set of keys. Does not modify or create a new trie, only wraps the existing `index._trie` object

Should be usable in any existing dvc-data functions that don't write back to the index (i.e. save, checkout, dvcfs methods, etc)

Implements

- `iteritems`
- `traverse`
- `ls`