### PR TITLE
index: build: introduce build_entry() and build_entries()

### DIFF
--- a/src/dvc_data/index/build.py
+++ b/src/dvc_data/index/build.py
@@ -1,8 +1,8 @@
 from itertools import chain
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Tuple
 
 from ..hashfile.meta import Meta
-from .index import DataIndex, DataIndexEntry
+from .index import DataIndex, DataIndexEntry, DataIndexKey
 
 if TYPE_CHECKING:
     from dvc_objects.fs.base import FileSystem
@@ -10,11 +10,24 @@ if TYPE_CHECKING:
     from ..hashfile._ignore import Ignore
 
 
-def build(
-    path: str, fs: "FileSystem", ignore: Optional["Ignore"] = None
-) -> DataIndex:
-    index = DataIndex()
+def build_entry(
+    path: str, fs: "FileSystem", info: Optional[Dict[str, Any]] = None
+):
+    if info is None:
+        info = fs.info(path)
 
+    return DataIndexEntry(
+        meta=Meta.from_info(info),
+        path=path,
+        fs=fs,
+    )
+
+
+def build_entries(
+    path: str,
+    fs: "FileSystem",
+    ignore: Optional["Ignore"] = None,
+) -> Iterable[Tuple[DataIndexKey, DataIndexEntry]]:
     walk_kwargs = {"detail": True}
     if ignore:
         walk_iter = ignore.walk(fs, path, **walk_kwargs)
@@ -28,10 +41,19 @@ def build(
             root_key = fs.path.relparts(root, path)
 
         for name, info in chain(dirs.items(), files.items()):
-            index[(*root_key, name)] = DataIndexEntry(
-                meta=Meta.from_info(info),
-                path=fs.path.join(root, name),
-                fs=fs,
+            yield (*root_key, name), build_entry(
+                fs.path.join(root, name),
+                fs,
+                info=info,
             )
+
+
+def build(
+    path: str, fs: "FileSystem", ignore: Optional["Ignore"] = None
+) -> DataIndex:
+    index = DataIndex()
+
+    for key, entry in build_entries(path, fs, ignore=ignore):
+        index[key] = entry
 
     return index


### PR DESCRIPTION
This is useful when trying to modify existing index (e.g. `dvc add`, including future 
`virtual directory` operations) 