### PR TITLE
index: introduce basic add()

### DIFF
--- a/src/dvc_data/index/__init__.py
+++ b/src/dvc_data/index/__init__.py
@@ -1,3 +1,4 @@
+from .add import add  # noqa: F401, pylint: disable=unused-import
 from .build import build  # noqa: F401, pylint: disable=unused-import
 from .checkout import checkout  # noqa: F401, pylint: disable=unused-import
 from .index import *  # noqa: F401,F403, pylint: disable=unused-import

--- a/src/dvc_data/index/add.py
+++ b/src/dvc_data/index/add.py
@@ -1,0 +1,24 @@
+from typing import TYPE_CHECKING, Optional
+
+from .build import build_entries, build_entry
+
+if TYPE_CHECKING:
+    from dvc_objects.fs import FileSystem
+
+    from ..hashfile._ignore import Ignore
+    from .index import DataIndex, DataIndexKey
+
+
+def add(
+    index: "DataIndex",
+    path: str,
+    fs: "FileSystem",
+    key: "DataIndexKey",
+    ignore: Optional["Ignore"] = None,
+):
+    if not fs.isdir(path):
+        index[key] = build_entry(path, fs)
+        return
+
+    for entry_key, entry in build_entries(path, fs, ignore=ignore):
+        index[(*key, *entry_key)] = entry

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -7,6 +7,7 @@ from dvc_data.hashfile.meta import Meta
 from dvc_data.index import (
     DataIndex,
     DataIndexEntry,
+    add,
     build,
     checkout,
     md5,
@@ -136,6 +137,35 @@ def test_build(tmp_upath, as_filesystem):
     assert index[("foo",)].fs == fs
     assert index[("foo",)].path == str(tmp_upath / "foo")
     assert index[("data",)].meta.isdir
+    assert index[("data", "bar")].meta.size == 4
+    assert index[("data", "bar")].fs == fs
+    assert index[("data", "bar")].path == str(tmp_upath / "data" / "bar")
+    assert index[("data", "baz")].meta.size == 4
+    assert index[("data", "baz")].fs == fs
+    assert index[("data", "baz")].path == str(tmp_upath / "data" / "baz")
+
+
+def test_add(tmp_upath, as_filesystem):
+    (tmp_upath / "foo").write_bytes(b"foo\n")
+    (tmp_upath / "data").mkdir()
+    (tmp_upath / "data" / "bar").write_bytes(b"bar\n")
+    (tmp_upath / "data" / "baz").write_bytes(b"baz\n")
+
+    fs = as_filesystem(tmp_upath.fs)
+    index = build(str(tmp_upath), fs)
+    index = DataIndex()
+
+    add(index, str(tmp_upath / "foo"), fs, ("foo",))
+    assert len(index) == 1
+    assert index[("foo",)].meta.size == 4
+    assert index[("foo",)].fs == fs
+    assert index[("foo",)].path == str(tmp_upath / "foo")
+
+    add(index, str(tmp_upath / "data"), fs, ("data",))
+    assert len(index) == 3
+    assert index[("foo",)].meta.size == 4
+    assert index[("foo",)].fs == fs
+    assert index[("foo",)].path == str(tmp_upath / "foo")
     assert index[("data", "bar")].meta.size == 4
     assert index[("data", "bar")].fs == fs
     assert index[("data", "bar")].path == str(tmp_upath / "data" / "bar")


### PR DESCRIPTION
Building entries from file/directory and adding them at a specific key. Similar to `dvc add`, but without hashing. Allows us to virtually add files/directories to the index, without having to have everything locally.