### PR TITLE
index: support checkout from entry source

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires=
     dictdiffer>=0.8.1
     pygtrie>=2.3.2
     shortuuid>=0.5.0
-    dvc-objects==0.7.0
+    dvc-objects==0.8.0
     diskcache>=5.2.1
     nanotime>=0.5.2
     attrs>=21.3.0

--- a/src/dvc_data/index/save.py
+++ b/src/dvc_data/index/save.py
@@ -60,7 +60,7 @@ def _save_dir_entry(
     setattr(entry.meta, tree.hash_info.name, tree.hash_info.value)
 
 
-def save(index: "BaseDataIndex", odb=None) -> None:
+def save(index: "BaseDataIndex", odb=None, **kwargs) -> None:
     dir_entries: List["DataIndexKey"] = []
 
     for key, entry in index.iteritems():
@@ -87,6 +87,7 @@ def save(index: "BaseDataIndex", odb=None) -> None:
                 path,
                 entry.fs,
                 entry.hash_info.value,
+                **kwargs,
             )
 
     for key in dir_entries:


### PR DESCRIPTION
- `index.checkout()` will first try to transfer from odb and then fall back to entry source if it is available
- Also unifies progress behavior between `hashfile.checkout()` and `index.checkout()`

This PR does not implement batching transfer operations by filesystem (will be done in a follow up). What we will need for that is a generic version version of `fs.get()`:
https://github.com/iterative/dvc-objects/blob/d28bbccc23fa8822ca2a01374bf11ff7362784a7/src/dvc_objects/fs/base.py#L447
(`fs.get()` is currently hard coded to only work when the dest is localfilesystem, but we can do the same thing with any filesystem)