### PR TITLE
hashfile: return oid sets instead of success/failed counts in transfer

### DIFF
--- a/src/dvc_data/hashfile/transfer.py
+++ b/src/dvc_data/hashfile/transfer.py
@@ -1,7 +1,15 @@
 import errno
 import logging
 from functools import partial, wraps
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterable,
+    NamedTuple,
+    Optional,
+    Set,
+)
 
 from dvc_objects._tqdm import Tqdm
 from dvc_objects.executors import ThreadPoolExecutor
@@ -18,26 +26,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class TransferError(Exception):
-    def __init__(self, fails: int) -> None:
-        self.fails = fails
-        super().__init__(f"{fails} transfer failed")
+class TransferResult(NamedTuple):
+    transferred: Set["HashInfo"]
+    failed: Set["HashInfo"]
 
 
-def _log_exceptions(func):
+def _log_exceptions(
+    func: Callable[["HashInfo"], None]
+) -> Callable[["HashInfo"], Optional["HashInfo"]]:
     @wraps(func)
-    def wrapper(path, *args, **kwargs):
+    def wrapper(oid: "HashInfo") -> Optional["HashInfo"]:
         try:
-            func(path, *args, **kwargs)
-            return 0
+            func(oid)
+            return None
         except Exception as exc:  # pylint: disable=broad-except
             # NOTE: this means we ran out of file descriptors and there is no
             # reason to try to proceed, as we will hit this error anyways.
             # pylint: disable=no-member
             if isinstance(exc, OSError) and exc.errno == errno.EMFILE:
                 raise
-            logger.exception("failed to transfer '%s'", path)
-            return 1
+            logger.exception("failed to transfer '%s'", oid)
+            return oid
 
     return wrapper
 
@@ -63,14 +72,21 @@ def _do_transfer(
     dest: "ObjectDB",
     obj_ids: Iterable["HashInfo"],
     missing_ids: Iterable["HashInfo"],
-    processor: Callable,
+    processor: Callable[
+        [Iterable["HashInfo"]], Iterable[Optional["HashInfo"]]
+    ],
     src_index: Optional["ObjectDBIndexBase"] = None,
     dest_index: Optional["ObjectDBIndexBase"] = None,
     cache_odb: Optional["ObjectDB"] = None,
     **kwargs: Any,
-):
+) -> Set["HashInfo"]:
+    """Do object transfer.
+
+    Returns:
+        Set containing any hash_infos which failed to transfer.
+    """
     dir_ids, file_ids = split(lambda hash_info: hash_info.isdir, obj_ids)
-    total_fails = 0
+    failed_ids: Set["HashInfo"] = set()
     succeeded_dir_objs = []
     all_file_ids = set(file_ids)
 
@@ -82,7 +98,11 @@ def _do_transfer(
         bound_file_ids = all_file_ids & entry_ids
         all_file_ids -= entry_ids
 
-        dir_fails = sum(processor(bound_file_ids))
+        dir_fails = [
+            hash_info
+            for hash_info in processor(bound_file_ids)
+            if hash_info is not None
+        ]
         if dir_fails:
             logger.debug(
                 "failed to upload full contents of '%s', "
@@ -94,7 +114,8 @@ def _do_transfer(
                 src.get(dir_obj.oid).path,
                 dest.get(dir_obj.oid).path,
             )
-            total_fails += dir_fails + 1
+            failed_ids.update(dir_fails)
+            failed_ids.add(dir_obj.hash_info)
         elif entry_ids.intersection(missing_ids):
             # if for some reason a file contained in this dir is
             # missing both locally and in the remote, we want to
@@ -106,17 +127,26 @@ def _do_transfer(
                 dir_hash,
             )
         else:
-            is_dir_failed = sum(processor([dir_obj.hash_info]))
-            total_fails += is_dir_failed
-            if not is_dir_failed:
+            is_dir_failed = any(
+                hash_info
+                for hash_info in processor([dir_obj.hash_info])
+                if hash_info is not None
+            )
+            if is_dir_failed:
+                failed_ids.add(dir_obj.hash_info)
+            else:
                 succeeded_dir_objs.append(dir_obj)
 
     # insert the rest
-    total_fails += sum(processor(all_file_ids))
-    if total_fails:
+    failed_ids.update(
+        hash_info
+        for hash_info in processor(all_file_ids)
+        if hash_info is not None
+    )
+    if failed_ids:
         if src_index:
             src_index.clear()
-        raise TransferError(total_fails)
+        return failed_ids
 
     # index successfully pushed dirs
     if dest_index:
@@ -130,6 +160,8 @@ def _do_transfer(
             assert dir_obj.hash_info and dir_obj.hash_info.value
             dest_index.update([dir_obj.hash_info.value], file_hashes)
 
+    return set()
+
 
 def transfer(
     src: "ObjectDB",
@@ -140,7 +172,7 @@ def transfer(
     hardlink: bool = False,
     validate_status: Callable[["CompareStatusResult"], None] = None,
     **kwargs,
-) -> int:
+) -> "TransferResult":
     """Transfer (copy) the specified objects from one ODB to another.
 
     Returns the number of successfully transferred objects
@@ -153,7 +185,7 @@ def transfer(
         dest.path,
     )
     if src == dest:
-        return 0
+        return TransferResult(set(), set())
 
     status = compare_status(
         src, dest, obj_ids, check_deleted=False, jobs=jobs, **kwargs
@@ -163,7 +195,7 @@ def transfer(
         validate_status(status)
 
     if not status.new:
-        return 0
+        return TransferResult(set(), set())
 
     def func(hash_info: "HashInfo") -> None:
         obj = src.get(hash_info.value)
@@ -181,7 +213,7 @@ def transfer(
         with ThreadPoolExecutor(max_workers=jobs) as executor:
             wrapped_func = pbar.wrap_fn(_log_exceptions(func))
             processor = partial(executor.imap_unordered, wrapped_func)
-            _do_transfer(
+            failed = _do_transfer(
                 src, dest, status.new, status.missing, processor, **kwargs
             )
-    return total
+    return TransferResult(status.new - failed, failed)


### PR DESCRIPTION
The dvc-data `transfer` implementations return integer counts due to legacy dvc push/fetch behavior reasons. We have the more detailed set data already and should just be returning that (and calling `len()` in dvc when needed for dvc UI purposes). This lets us handle fallback behavior in DVC (where we can potentially get objects that failed to transfer from an alternate source)