### PR TITLE
index: update entry fs/path on checkout

### DIFF
--- a/src/dvc_data/index/checkout.py
+++ b/src/dvc_data/index/checkout.py
@@ -67,6 +67,8 @@ def checkout(
                     entry_path,
                     callback=callback,
                 )
+                entry.fs = fs
+                entry.path = entry_path
                 entry.meta = Meta.from_info(fs.info(entry_path))
                 break
             except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
If we are updating `entry.meta` on checkout we also need to update `entry.fs` and `entry.path`, otherwise we cannot validate metadata using `entry.meta == Meta.from_info(entry.fs.info(entry.path))`