### PR TITLE
index: diff: add with_unchanged

### DIFF
--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -27,6 +27,8 @@ class Change:
 def _diff(
     old: Optional["BaseDataIndex"],
     new: Optional["BaseDataIndex"],
+    *,
+    with_unchanged: Optional[bool] = False,
     meta_only: Optional[bool] = False,
 ):
     old_keys = {key for key, _ in old.iteritems()} if old else set()
@@ -49,6 +51,8 @@ def _diff(
             typ = MODIFY
         elif old_meta != new_meta:
             typ = MODIFY
+        elif not with_unchanged:
+            continue
 
         yield Change(typ, old_entry, new_entry)
 
@@ -91,10 +95,17 @@ def _detect_renames(changes: Iterable[Change]):
 def diff(
     old: Optional["BaseDataIndex"],
     new: Optional["BaseDataIndex"],
+    *,
     with_renames: Optional[bool] = False,
+    with_unchanged: Optional[bool] = False,
     meta_only: Optional[bool] = False,
 ):
-    changes = _diff(old, new, meta_only=meta_only)
+    changes = _diff(
+        old,
+        new,
+        with_unchanged=with_unchanged,
+        meta_only=meta_only,
+    )
 
     if with_renames and old is not None and new is not None:
         assert not meta_only

--- a/src/dvc_data/index/update.py
+++ b/src/dvc_data/index/update.py
@@ -7,6 +7,6 @@ if TYPE_CHECKING:
 
 
 def update(new: "DataIndex", old: "BaseDataIndex") -> None:
-    for change in diff(old, new, meta_only=True):
+    for change in diff(old, new, with_unchanged=True, meta_only=True):
         if change.typ == UNCHANGED:
             change.new.hash_info = change.old.hash_info

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -368,11 +368,11 @@ def test_diff():
     )
     old = DataIndex({old_foo_key: old_foo_entry, old_bar_key: old_bar_entry})
 
-    assert set(diff(old, old)) == {
+    assert set(diff(old, old, with_unchanged=True)) == {
         Change(UNCHANGED, old_foo_entry, old_foo_entry),
         Change(UNCHANGED, old_bar_entry, old_bar_entry),
     }
-    assert set(diff(old, old, with_renames=True)) == {
+    assert set(diff(old, old, with_renames=True, with_unchanged=True)) == {
         Change(UNCHANGED, old_foo_entry, old_foo_entry),
         Change(UNCHANGED, old_bar_entry, old_bar_entry),
     }
@@ -394,12 +394,12 @@ def test_diff():
         }
     )
 
-    assert set(diff(old, new)) == {
+    assert set(diff(old, new, with_unchanged=True)) == {
         Change(ADD, None, new_foo_entry),
         Change(DELETE, old_foo_entry, None),
         Change(UNCHANGED, old_bar_entry, old_bar_entry),
     }
-    assert set(diff(old, new, with_renames=True)) == {
+    assert set(diff(old, new, with_renames=True, with_unchanged=True)) == {
         Change(RENAME, old_foo_entry, new_foo_entry),
         Change(UNCHANGED, old_bar_entry, old_bar_entry),
     }


### PR DESCRIPTION
We don't always want unchanged entries, so we can save up on creating a lot of redundant objects in those cases.