### PR TITLE
index: info: use entry.meta

### DIFF
--- a/src/dvc_data/index/index.py
+++ b/src/dvc_data/index/index.py
@@ -132,9 +132,8 @@ class BaseDataIndex(ABC, Mapping[DataIndexKey, DataIndexEntry]):
     def info(self, key: DataIndexKey):
         try:
             entry = self[key]
-            isdir = entry.hash_info and entry.hash_info.isdir
-            assert entry.hash_info is not None
-            return {
+            isdir = entry.meta and entry.meta.isdir
+            ret = {
                 "type": "directory" if isdir else "file",
                 "size": entry.meta.size if entry.meta else 0,
                 "isexec": entry.meta.isexec if entry.meta else False,
@@ -142,8 +141,13 @@ class BaseDataIndex(ABC, Mapping[DataIndexKey, DataIndexEntry]):
                 "isout": True,
                 "obj": entry.obj,
                 "entry": entry,
-                entry.hash_info.name: entry.hash_info.value,
             }
+
+            if entry.hash_info:
+                assert entry.hash_info.name
+                ret[entry.hash_info.name] = entry.hash_info.value
+
+            return ret
         except ShortKeyError:
             return {
                 "type": "directory",

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -67,6 +67,7 @@ def test_fs(tmp_upath, odb, as_filesystem):
             ),
             ("data",): DataIndexEntry(
                 odb=odb,
+                meta=Meta(isdir=True),
                 hash_info=HashInfo(
                     name="md5",
                     value="1f69c66028c35037e8bf67e5bc4ceb6a.dir",


### PR DESCRIPTION
Relying on `meta` is more correct as `hash_info` containing `isdir` is an implementation detail that will not stick around forever. This also allows us to handle temporary directories that we create when loading tree object or when building a new index.