### PR TITLE
_build_tree: Fix rel_key for path with trailing fs.sep.

### DIFF
--- a/src/dvc_data/hashfile/build.py
+++ b/src/dvc_data/hashfile/build.py
@@ -131,10 +131,7 @@ def _build_tree(
             # faster string manipulation instead of a more robust relparts()
             rel_key: Tuple[Optional[Any], ...] = ()
             if root != path:
-                path_lenght = len(path)
-                if not path.endswith(fs.sep):
-                    path_lenght += 1
-                rel_key = tuple(root[path_lenght:].split(fs.sep))
+                rel_key = tuple(root[len(path) + 1 :].split(fs.sep))
 
             for fname in fnames:
                 if fname == "":

--- a/src/dvc_data/hashfile/build.py
+++ b/src/dvc_data/hashfile/build.py
@@ -98,6 +98,8 @@ def _build_tree(
         except FileNotFoundError:
             pass
 
+    path = path.rstrip(fs.sep)
+
     if ignore:
         walk_iter = ignore.walk(fs, path)
     else:


### PR DESCRIPTION
The string manipulation used as alternative to `relparts` didn't handle the case of `path` containing a trailing fs.sep, creating a `rel_key` with the first letter missing.

Fixes https://github.com/iterative/dvc/issues/8572