### PR TITLE
gc: Pass list of paths to `fs.remove`.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires=
     dictdiffer>=0.8.1
     pygtrie>=2.3.2
     shortuuid>=0.5.0
-    dvc-objects==0.16.0
+    dvc-objects==0.17.0
     diskcache>=5.2.1
     nanotime>=0.5.2
     attrs>=21.3.0


### PR DESCRIPTION
Use "bulk" remove in filesystems that support it.

Requires https://github.com/iterative/dvc-objects/pull/176 to don't break in localfs

Closes https://github.com/iterative/dvc/issues/5961