### PR TITLE
index: parallelize checkout/save

### DIFF
--- a/src/dvc_data/index/checkout.py
+++ b/src/dvc_data/index/checkout.py
@@ -73,6 +73,7 @@ def _do_create(
         and entry.meta.version_id is not None
         and fs.exists(fs.path.version_path(entry_path, entry.meta.version_id))
     ):
+        callback.relative_update()
         return 0
 
     sources = []

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -183,6 +183,7 @@ def test_checkout(tmp_upath, odb, as_filesystem):
         {
             ("foo",): DataIndexEntry(
                 key=("foo",),
+                meta=Meta(),
                 odb=odb,
                 hash_info=HashInfo(
                     name="md5", value="d3b07384d113edec49eaa6238ad5ff00"


### PR DESCRIPTION
Related: https://github.com/iterative/dvc/issues/8359

@dberenbaum It looks like the main performance issue was that remote file transfers weren't being parallelized/batched properly for versioned remotes. Can you test with this PR and confirm that it resolves the performance issues you were seeing? Just note that `--jobs` won't be respected properly w/this PR (it will always just use the cpu core # based default). Fixing `--jobs` will need an additional change in downstream dvc once the dvc-data changes get released.

I'd prefer to not add more usage of `ThreadPoolExecutor` and am going to look into doing a proper asyncio based implementation instead, but we could consider merging this in the meantime.