### PR TITLE
index: use sqltrie

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires=
     diskcache>=5.2.1
     nanotime>=0.5.2
     attrs>=21.3.0
+    sqltrie==0.0.24
 
 [options.extras_require]
 cli =

--- a/src/dvc_data/index/index.py
+++ b/src/dvc_data/index/index.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
+from functools import cached_property
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -12,11 +13,12 @@ from typing import (
     MutableMapping,
     Optional,
     Tuple,
+    cast,
 )
 
 from dvc_objects.errors import ObjectFormatError
-from pygtrie import ShortKeyError  # noqa: F401, pylint: disable=unused-import
-from pygtrie import Trie
+from sqltrie import ShortKeyError  # noqa: F401, pylint: disable=unused-import
+from sqltrie import JSONTrie, PyGTrie, SQLiteTrie
 
 from ..hashfile.hash_info import HashInfo
 from ..hashfile.meta import Meta
@@ -59,10 +61,12 @@ class DataIndexEntry:
         if hash_info:
             ret.hash_info = HashInfo.from_dict(hash_info)
 
+        ret.loaded = cast(bool, d["loaded"])
+
         return ret
 
-    def to_dict(self) -> Dict[str, Dict]:
-        ret = {}
+    def to_dict(self) -> Dict[str, Any]:
+        ret: Dict[str, Any] = {}
 
         if self.meta:
             ret["meta"] = self.meta.to_dict()
@@ -70,7 +74,45 @@ class DataIndexEntry:
         if self.hash_info:
             ret["hash_info"] = self.hash_info.to_dict()
 
+        ret["loaded"] = self.loaded
+
         return ret
+
+
+class DataIndexTrie(JSONTrie):
+    def __init__(self, *args, **kwargs):
+        self._cache = {}
+        super().__init__(*args, **kwargs)
+
+    @cached_property
+    def _trie(self):
+        return SQLiteTrie()
+
+    @classmethod
+    def open(cls, path):
+        ret = cls()
+        ret._trie = SQLiteTrie.open(path)
+        return ret
+
+    def _load(self, key, value):
+        try:
+            return self._cache[key]
+        except KeyError:
+            pass
+        if value is None:
+            return None
+        return DataIndexEntry.from_dict(super()._load(key, value))
+
+    def _dump(self, key, value):
+        if key not in self._cache:
+            self._cache[key] = value
+        if value is None:
+            return None
+        return super()._dump(key, value.to_dict())
+
+    def __delitem__(self, key):
+        self._cache.pop(key, None)
+        super().__delitem__(key)
 
 
 def _try_load(
@@ -110,45 +152,8 @@ class BaseDataIndex(ABC, Mapping[DataIndexKey, DataIndexEntry]):
     ) -> Tuple[Optional[DataIndexKey], Optional[DataIndexEntry]]:
         pass
 
-    def ls(self, root_key: DataIndexKey, detail=True):
-        if not detail:
-
-            def node_factory(_, key, children, *args):
-                if key == root_key:
-                    return children
-                else:
-                    return key
-
-        else:
-
-            def node_factory(_, key, children, *args):
-                if key == root_key:
-                    return children
-                else:
-                    return key, self.info(key)
-
-        return self.traverse(node_factory, prefix=root_key)
-
-    def info(self, key: DataIndexKey):
-        try:
-            entry = self[key]
-            isdir = entry.meta and entry.meta.isdir
-            ret = {
-                "type": "directory" if isdir else "file",
-                "size": entry.meta.size if entry.meta else 0,
-                "isexec": entry.meta.isexec if entry.meta else False,
-                "isdvc": True,
-                "isout": True,
-                "obj": entry.obj,
-                "entry": entry,
-            }
-
-            if entry.hash_info:
-                assert entry.hash_info.name
-                ret[entry.hash_info.name] = entry.hash_info.value
-
-            return ret
-        except ShortKeyError:
+    def _info_from_entry(self, key, entry):
+        if entry is None:
             return {
                 "type": "directory",
                 "size": 0,
@@ -158,13 +163,65 @@ class BaseDataIndex(ABC, Mapping[DataIndexKey, DataIndexEntry]):
                 "obj": None,
                 "entry": None,
             }
+
+        isdir = entry.meta and entry.meta.isdir
+        ret = {
+            "type": "directory" if isdir else "file",
+            "size": entry.meta.size if entry.meta else 0,
+            "isexec": entry.meta.isexec if entry.meta else False,
+            "isdvc": True,
+            "isout": True,
+            "obj": entry.obj,
+            "entry": entry,
+        }
+
+        if entry.hash_info:
+            assert entry.hash_info.name
+            ret[entry.hash_info.name] = entry.hash_info.value
+
+        return ret
+
+    @abstractmethod
+    def ls(self, root_key: DataIndexKey, detail=True):
+        pass
+
+    def info(self, key: DataIndexKey):
+        try:
+            entry = self[key]
+        except ShortKeyError:
+            entry = None
         except KeyError as exc:
             raise FileNotFoundError from exc
+
+        return self._info_from_entry(key, entry)
 
 
 class DataIndex(BaseDataIndex, MutableMapping[DataIndexKey, DataIndexEntry]):
     def __init__(self, *args, **kwargs):
-        self._trie = Trie(*args, **kwargs)
+        # NOTE: by default, using an in-memory pygtrie trie that doesn't
+        # serialize values, so we can save some time.
+        self._trie = PyGTrie()
+        self.update(*args, **kwargs)
+
+    @classmethod
+    def open(cls, path):
+        ret = cls()
+        ret._trie = DataIndexTrie.open(path)
+        return ret
+
+    def view(self, key):
+        ret = DataIndex()
+        ret._trie = self._trie.view(key)  # pylint: disable=protected-access
+        return ret
+
+    def commit(self):
+        self._trie.commit()
+
+    def rollback(self):
+        self._trie.rollback()
+
+    def close(self):
+        self._trie.close()
 
     def __setitem__(self, key, value):
         self._trie[key] = value
@@ -174,8 +231,11 @@ class DataIndex(BaseDataIndex, MutableMapping[DataIndexKey, DataIndexEntry]):
         if item:
             return item
 
-        dir_key, dir_entry = self._trie.longest_prefix(key)
-        self._load(dir_key, dir_entry)
+        lprefix = self._trie.longest_prefix(key)
+        if lprefix is not None:
+            dir_key, dir_entry = lprefix
+            self._load(dir_key, dir_entry)
+
         return self._trie[key]
 
     def __delitem__(self, key):
@@ -248,6 +308,9 @@ class DataIndex(BaseDataIndex, MutableMapping[DataIndexKey, DataIndexEntry]):
             )
 
         entry.loaded = True
+        del self._trie[key]
+        self._trie[key] = entry
+        self._trie.commit()
 
     def load(self, **kwargs):
         for key, entry in self.iteritems(shallow=True, **kwargs):
@@ -278,12 +341,14 @@ class DataIndex(BaseDataIndex, MutableMapping[DataIndexKey, DataIndexEntry]):
                 key, entry = item
                 self._load(key, entry)
 
-        for key, entry in self._trie.iteritems(**kwargs):
+        # FIXME could filter by loaded and/or isdir in sql on sqltrie side
+        for key, entry in self._trie.items(**kwargs):
             self._load(key, entry)
-            yield key, entry
+
+        yield from self._trie.items(**kwargs)
 
     def iterkeys(self, *args, **kwargs):
-        return self._trie.iterkeys(*args, **kwargs)
+        return self._trie.keys(*args, **kwargs)
 
     def _ensure_loaded(self, prefix):
         entry = self._trie.get(prefix)
@@ -299,7 +364,13 @@ class DataIndex(BaseDataIndex, MutableMapping[DataIndexKey, DataIndexEntry]):
 
     def ls(self, root_key: DataIndexKey, detail=True):
         self._ensure_loaded(root_key)
-        return super().ls(root_key, detail=detail)
+        if detail:
+            yield from (
+                (key, self._info_from_entry(key, entry))
+                for key, entry in self._trie.ls(root_key, with_values=True)
+            )
+        else:
+            yield from self._trie.ls(root_key)
 
 
 def transfer(index, src, dst):

--- a/src/dvc_data/index/serialize.py
+++ b/src/dvc_data/index/serialize.py
@@ -19,7 +19,7 @@ def read_db(path: str) -> DataIndex:
         for key in cache:
             value = cache.get(key)
             entry = DataIndexEntry.from_dict(value)
-            entry.key = key.split("/")
+            entry.key = tuple(key.split("/"))  # type: ignore
             index.add(entry)
 
     return index
@@ -42,7 +42,7 @@ def read_json(path: str) -> DataIndex:
     with open(path, "r", encoding="utf-8") as fobj:
         for key, value in json.load(fobj).items():
             entry = DataIndexEntry.from_dict(value)
-            entry.key = key.split("/")
+            entry.key = tuple(key.split("/"))  # type: ignore
             index.add(entry)
 
     return index

--- a/src/dvc_data/index/view.py
+++ b/src/dvc_data/index/view.py
@@ -102,6 +102,18 @@ class DataIndexView(BaseDataIndex):
 
         return self._index.traverse(_node_factory, **kwargs)
 
+    def ls(self, root_key: DataIndexKey, detail=True):
+        def node_factory(_, key, children, entry=None):
+            if key == root_key:
+                return children
+
+            if detail:
+                return key, self._info_from_entry(key, entry)
+
+            return key
+
+        return self.traverse(node_factory, prefix=root_key)
+
     def has_node(self, key: DataIndexKey) -> bool:
         return self.filter_fn(key) and self._index.has_node(key)
 


### PR DESCRIPTION
This patch, makes us use sqltrie wrapper for pygtrie when working in memory to achive the parity with the old behavior, but also adds an `open` method that will need to be explicitly utilized by `dvc` to actually start using a persistent sqlite-based index.

Fixes #208