### PR TITLE
index: diff: introduce with_unknown flag

### DIFF
--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -1,3 +1,4 @@
+from collections import deque
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional
 
 from attrs import define
@@ -7,6 +8,7 @@ if TYPE_CHECKING:
     from .hashfile.hash_info import HashInfo
     from .index import BaseDataIndex, DataIndexKey
 
+from ..hashfile.tree import TreeError
 from .index import DataIndexEntry
 
 ADD = "add"
@@ -14,6 +16,7 @@ MODIFY = "modify"
 RENAME = "rename"
 DELETE = "delete"
 UNCHANGED = "unchanged"
+UNKNOWN = "unknown"
 
 
 @define(frozen=True, hash=True, order=True)
@@ -27,7 +30,9 @@ class Change:
         if self.typ == RENAME:
             raise ValueError
 
-        if self.typ == ADD:
+        if self.typ == UNKNOWN:
+            entry = self.old or self.new
+        elif self.typ == ADD:
             entry = self.new
         else:
             entry = self.old
@@ -78,7 +83,17 @@ def _diff_entry(
     hash_only: Optional[bool] = False,
     meta_only: Optional[bool] = False,
     meta_cmp_key: Optional[Callable[["Meta"], Any]] = None,
+    unknown: Optional[bool] = False,
 ):
+    if unknown:
+        return UNKNOWN
+
+    if old and not new:
+        return DELETE
+
+    if not old and new:
+        return ADD
+
     old_hi = old.hash_info if old else None
     new_hi = new.hash_info if new else None
     old_meta = old.meta if old else None
@@ -102,45 +117,74 @@ def _diff_entry(
     return UNCHANGED
 
 
+def _get_items(index, key, entry, *, shallow=False, with_unknown=False):
+    items = {}
+    unknown = False
+
+    try:
+        if index and not (shallow and entry):
+            items = dict(index.ls(key, detail=True))
+    except KeyError:
+        pass
+    except TreeError:
+        unknown = with_unknown
+
+    return items, unknown
+
+
 def _diff(
     old: Optional["BaseDataIndex"],
     new: Optional["BaseDataIndex"],
     *,
     with_unchanged: Optional[bool] = False,
+    with_unknown: Optional[bool] = False,
     hash_only: Optional[bool] = False,
     meta_only: Optional[bool] = False,
     meta_cmp_key: Optional[Callable[["Meta"], Any]] = None,
     shallow: Optional[bool] = False,
 ):
-    old_keys = (
-        {key for key, _ in old.iteritems(shallow=shallow)} if old else set()
-    )
-    new_keys = (
-        {key for key, _ in new.iteritems(shallow=shallow)} if new else set()
-    )
+    todo = deque([((), None, None, False)])
+    while todo:
+        dirkey, old_direntry, new_direntry, unknown = todo.popleft()
 
-    for key in old_keys | new_keys:
-        old_entry = old.get(key) if old is not None else None
-        new_entry = new.get(key) if new is not None else None
+        kwargs = {"shallow": shallow, "with_unknown": with_unknown}
+        old_items, old_unknown = _get_items(
+            old, dirkey, old_direntry, **kwargs
+        )
+        new_items, new_unknown = _get_items(
+            new, dirkey, new_direntry, **kwargs
+        )
+        unknown = old_unknown or new_unknown
 
-        typ = UNCHANGED
-        if old_entry and not new_entry:
-            typ = DELETE
-        elif not old_entry and new_entry:
-            typ = ADD
-        else:
+        for key in old_items.keys() | new_items.keys():
+            old_info = old_items.get(key) or {}
+            new_info = new_items.get(key) or {}
+
+            old_entry = old_info.get("entry")
+            new_entry = new_info.get("entry")
+
             typ = _diff_entry(
                 old_entry,
                 new_entry,
                 hash_only=hash_only,
                 meta_only=meta_only,
                 meta_cmp_key=meta_cmp_key,
+                unknown=unknown,
             )
 
-        if typ == UNCHANGED and not with_unchanged:
-            continue
+            if (
+                old_info.get("type") == "directory"
+                or new_info.get("type") == "directory"
+            ):
+                todo.append((key, old_entry, new_entry, unknown))
 
-        yield Change(typ, old_entry, new_entry)
+            if old_entry is None and new_entry is None:
+                continue
+
+            if typ == UNCHANGED and not with_unchanged:
+                continue
+
+            yield Change(typ, old_entry, new_entry)
 
 
 def _detect_renames(changes: Iterable[Change]):
@@ -195,6 +239,7 @@ def diff(
     *,
     with_renames: Optional[bool] = False,
     with_unchanged: Optional[bool] = False,
+    with_unknown: Optional[bool] = False,
     hash_only: Optional[bool] = False,
     meta_only: Optional[bool] = False,
     meta_cmp_key: Optional[Callable[["Meta"], Any]] = None,
@@ -204,6 +249,7 @@ def diff(
         old,
         new,
         with_unchanged=with_unchanged,
+        with_unknown=with_unknown,
         hash_only=hash_only,
         meta_only=meta_only,
         meta_cmp_key=meta_cmp_key,


### PR DESCRIPTION
This state is occuring when we are comparing two indexes and one of those knows that there is a directory with a specific hash, but can't load the info about it (e.g. cache file is missing), which means that `diff` doesn't have enough info to figure out what's changed and it looks like added/deleted entries.

This state was introduced in `dvc data status` last year and is already used by vscode.

This PR is putting it into index diff terms so we can reuse it in other places (e.g. `dvc diff`).

Pre-requisite to migrating `dvc data status` to `DataIndex` and https://github.com/iterative/dvc/issues/8761

Fixes index side of #83