### PR TITLE
index: fix checkout with views

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires=
     dictdiffer>=0.8.1
     pygtrie>=2.3.2
     shortuuid>=0.5.0
-    dvc-objects==0.18.2
+    dvc-objects==0.19.0
     diskcache>=5.2.1
     nanotime>=0.5.2
     attrs>=21.3.0

--- a/src/dvc_data/index/checkout.py
+++ b/src/dvc_data/index/checkout.py
@@ -96,14 +96,11 @@ def checkout(
                 desc = f"Updating meta for new files in '{path}'"
                 cb = Callback.as_tqdm_callback(desc=desc, unit="file")
             with cb:
-                cb.set_size(len(args))
-                for entry, _src_path, dest_path in args:
+                infos = fs.info(list(dest_paths), callback=cb, batch_size=jobs)
+                for entry, dest_path, info in zip(entries, dest_paths, infos):
                     entry.fs = fs
                     entry.path = dest_path
-                    entry.meta = Meta.from_info(
-                        fs.info(dest_path), fs.protocol
-                    )
-                    cb.relative_update()
+                    entry.meta = Meta.from_info(info, fs.protocol)
     return transferred
 
 

--- a/src/dvc_data/index/view.py
+++ b/src/dvc_data/index/view.py
@@ -114,6 +114,9 @@ class DataIndexView(BaseDataIndex):
 
             return key
 
+        self._index._ensure_loaded(  # pylint: disable=protected-access
+            root_key
+        )
         return self.traverse(node_factory, prefix=root_key)
 
     def has_node(self, key: DataIndexKey) -> bool:


### PR DESCRIPTION
- force dir load on `view.ls()` (used in new diff behavior)
- use batched `fs.info` when possible in checkout

Will fix https://github.com/iterative/dvc/issues/8852