### PR TITLE
index.diff: check for not None instead of boolean check which calls _…

### DIFF
--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -117,12 +117,19 @@ def _diff_entry(
     return UNCHANGED
 
 
-def _get_items(index, key, entry, *, shallow=False, with_unknown=False):
+def _get_items(
+    index: Optional["BaseDataIndex"],
+    key,
+    entry,
+    *,
+    shallow=False,
+    with_unknown=False,
+):
     items = {}
     unknown = False
 
     try:
-        if index and not (shallow and entry):
+        if index is not None and not (shallow and entry):
             items = dict(index.ls(key, detail=True))
     except KeyError:
         pass


### PR DESCRIPTION
…_len__

On my local benchmark, I saw it drop on `dvc data status` from 20s to 14s, a 30% reduction. The `index` conditional check calls `__len__` which in turn calls `len(self._trie)`, which takes a lot of time because it gets called a lot of time.

![Screenshot from 2023-01-24 11-30-00](https://user-images.githubusercontent.com/18718008/214220736-d6c33707-7be7-4673-9a10-298b15a06e54.png)
