### PR TITLE
index: diff: handle missing hash in hash_only mode

### DIFF
--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -30,12 +30,12 @@ class Change:
         if self.typ == RENAME:
             raise ValueError
 
-        if self.typ == UNKNOWN:
-            entry = self.old or self.new
-        elif self.typ == ADD:
+        if self.typ == ADD:
             entry = self.new
-        else:
+        elif self.typ == DELETE:
             entry = self.old
+        else:
+            entry = self.old or self.new
 
         assert entry
         assert entry.key
@@ -88,12 +88,6 @@ def _diff_entry(
     if unknown:
         return UNKNOWN
 
-    if old and not new:
-        return DELETE
-
-    if not old and new:
-        return ADD
-
     old_hi = old.hash_info if old else None
     new_hi = new.hash_info if new else None
     old_meta = old.meta if old else None
@@ -109,10 +103,10 @@ def _diff_entry(
         return hi_diff
 
     if meta_diff != UNCHANGED:
-        return MODIFY
+        return meta_diff
 
     if hi_diff != UNCHANGED:
-        return MODIFY
+        return hi_diff
 
     return UNCHANGED
 

--- a/tests/index/test_diff.py
+++ b/tests/index/test_diff.py
@@ -1,0 +1,67 @@
+from dvc_data.hashfile.hash_info import HashInfo
+from dvc_data.index import DataIndex, DataIndexEntry
+from dvc_data.index.diff import ADD, DELETE, RENAME, UNCHANGED, Change, diff
+
+
+def test_diff():
+    old_foo_key = ("foo",)
+    old_foo_entry = DataIndexEntry(
+        key=old_foo_key,
+        hash_info=HashInfo(
+            name="md5", value="d3b07384d113edec49eaa6238ad5ff00"
+        ),
+    )
+    old_bar_key = ("dir", "subdir", "bar")
+    old_bar_entry = DataIndexEntry(
+        key=old_bar_key,
+        hash_info=HashInfo(
+            name="md5",
+            value="1f69c66028c35037e8bf67e5bc4ceb6a.dir",
+        ),
+    )
+    old = DataIndex({old_foo_key: old_foo_entry, old_bar_key: old_bar_entry})
+
+    assert set(diff(old, old, with_unchanged=True)) == {
+        Change(UNCHANGED, old_foo_entry, old_foo_entry),
+        Change(UNCHANGED, old_bar_entry, old_bar_entry),
+    }
+    assert set(diff(old, old, with_renames=True, with_unchanged=True)) == {
+        Change(UNCHANGED, old_foo_entry, old_foo_entry),
+        Change(UNCHANGED, old_bar_entry, old_bar_entry),
+    }
+
+    new_foo_key = ("data", "FOO")
+    new_foo_entry = DataIndexEntry(
+        key=new_foo_key,
+        hash_info=HashInfo(
+            name="md5", value="d3b07384d113edec49eaa6238ad5ff00"
+        ),
+    )
+    new = DataIndex(
+        {
+            (
+                "data",
+                "FOO",
+            ): new_foo_entry,
+            old_bar_key: old_bar_entry,
+        }
+    )
+
+    assert set(diff(old, new, with_unchanged=True)) == {
+        Change(ADD, None, new_foo_entry),
+        Change(DELETE, old_foo_entry, None),
+        Change(UNCHANGED, old_bar_entry, old_bar_entry),
+    }
+    assert set(diff(old, new, with_renames=True, with_unchanged=True)) == {
+        Change(RENAME, old_foo_entry, new_foo_entry),
+        Change(UNCHANGED, old_bar_entry, old_bar_entry),
+    }
+
+
+def test_diff_no_hashes():
+    index = DataIndex(
+        {
+            ("foo",): DataIndexEntry(key=("foo",)),
+        }
+    )
+    assert not set(diff(index, None, hash_only=True))

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -10,7 +10,6 @@ from dvc_data.index import (
     add,
     build,
     checkout,
-    diff,
     md5,
     read_db,
     read_json,
@@ -395,63 +394,6 @@ def test_view_traverse(odb):
         ("dir", "subdir"),
         ("dir", "subdir", "bar"),
     ]
-
-
-def test_diff():
-    from dvc_data.index.diff import ADD, DELETE, RENAME, UNCHANGED, Change
-
-    old_foo_key = ("foo",)
-    old_foo_entry = DataIndexEntry(
-        key=old_foo_key,
-        hash_info=HashInfo(
-            name="md5", value="d3b07384d113edec49eaa6238ad5ff00"
-        ),
-    )
-    old_bar_key = ("dir", "subdir", "bar")
-    old_bar_entry = DataIndexEntry(
-        key=old_bar_key,
-        hash_info=HashInfo(
-            name="md5",
-            value="1f69c66028c35037e8bf67e5bc4ceb6a.dir",
-        ),
-    )
-    old = DataIndex({old_foo_key: old_foo_entry, old_bar_key: old_bar_entry})
-
-    assert set(diff(old, old, with_unchanged=True)) == {
-        Change(UNCHANGED, old_foo_entry, old_foo_entry),
-        Change(UNCHANGED, old_bar_entry, old_bar_entry),
-    }
-    assert set(diff(old, old, with_renames=True, with_unchanged=True)) == {
-        Change(UNCHANGED, old_foo_entry, old_foo_entry),
-        Change(UNCHANGED, old_bar_entry, old_bar_entry),
-    }
-
-    new_foo_key = ("data", "FOO")
-    new_foo_entry = DataIndexEntry(
-        key=new_foo_key,
-        hash_info=HashInfo(
-            name="md5", value="d3b07384d113edec49eaa6238ad5ff00"
-        ),
-    )
-    new = DataIndex(
-        {
-            (
-                "data",
-                "FOO",
-            ): new_foo_entry,
-            old_bar_key: old_bar_entry,
-        }
-    )
-
-    assert set(diff(old, new, with_unchanged=True)) == {
-        Change(ADD, None, new_foo_entry),
-        Change(DELETE, old_foo_entry, None),
-        Change(UNCHANGED, old_bar_entry, old_bar_entry),
-    }
-    assert set(diff(old, new, with_renames=True, with_unchanged=True)) == {
-        Change(RENAME, old_foo_entry, new_foo_entry),
-        Change(UNCHANGED, old_bar_entry, old_bar_entry),
-    }
 
 
 def test_update(tmp_upath, odb, as_filesystem):


### PR DESCRIPTION
Previously if one index had a file without hash and second had no file at all diff would say that this file was added/deleted in `hash_only=True` mode, which is incorrect.

See https://github.com/iterative/dvc/pull/8878#discussion_r1086346424