### PR TITLE
index: ignore None diff entries on checkout

### DIFF
--- a/src/dvc_data/index/checkout.py
+++ b/src/dvc_data/index/checkout.py
@@ -113,8 +113,10 @@ def _get_changes(
         if change.typ == ADD:
             create.append(change.new)
         elif change.typ == MODIFY:
-            create.append(change.new)
-            delete.append(change.old)
+            if change.new:
+                create.append(change.new)
+            if change.old:
+                delete.append(change.old)
         elif change.typ == DELETE and delete:
             delete.append(change.old)
     return create, delete


### PR DESCRIPTION
When diffing with meta only (and ignoring hash info) it's possible to get a `MODIFY` change w/`None` value in old/new