### PR TITLE
index: replace entry.odb/cache/remote with index.odb/remote_map

### DIFF
--- a/src/dvc_data/fs.py
+++ b/src/dvc_data/fs.py
@@ -53,16 +53,18 @@ class DataFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
 
         entry = info["entry"]
 
-        cache_path = entry.odb.oid_to_path(value)
+        odb = self.index.odb_map.get(entry.key)
+        if odb:
+            cache_path = odb.oid_to_path(value)
+            if odb.fs.exists(cache_path):
+                return odb.fs, cache_path
 
-        if entry.odb.fs.exists(cache_path):
-            return entry.odb.fs, cache_path
+        remote = self.index.remote_map.get(entry.key)
+        if remote:
+            remote_path = remote.oid_to_path(value)
+            return remote.fs, remote_path
 
-        if not entry.remote:
-            raise FileNotFoundError
-
-        remote_fs_path = entry.remote.oid_to_path(value)
-        return entry.remote.fs, remote_fs_path
+        raise FileNotFoundError
 
     def open(  # type: ignore
         self, path: str, mode="r", encoding=None, **kwargs

--- a/src/dvc_data/index/checkout.py
+++ b/src/dvc_data/index/checkout.py
@@ -70,7 +70,9 @@ def checkout(
             src_path = entry.path
         else:
             assert entry.hash_info
-            odb = entry.odb or entry.cache or entry.remote
+            odb = index.odb_map.get(entry.key) or index.remote_map.get(
+                entry.key
+            )
             assert odb
             src_fs = odb.fs
             src_path = odb.oid_to_path(entry.hash_info.value)

--- a/src/dvc_data/index/save.py
+++ b/src/dvc_data/index/save.py
@@ -88,7 +88,7 @@ def _save_dir_entry(
     from ..hashfile.db import add_update_tree
 
     entry = index[key]
-    cache = odb or entry.cache
+    cache = odb or index.odb_map[key]
     assert cache
     meta, tree = build_tree(index, key)
     tree = add_update_tree(cache, tree)
@@ -142,7 +142,7 @@ def save(
         else:
             path = entry.path
         if entry.hash_info:
-            cache = odb or entry.cache
+            cache = odb or index.odb_map[key]
             assert cache
             assert entry.hash_info.value
             oid = entry.hash_info.value


### PR DESCRIPTION
Removes unserializable HashFileDB objects from DataIndexEntry, so we can reload index from persistent storage and still be able to use it where we need it.

Fixes #287