### PR TITLE
index: introduce storage_map

### DIFF
--- a/src/dvc_data/fs.py
+++ b/src/dvc_data/fs.py
@@ -53,13 +53,14 @@ class DataFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
 
         entry = info["entry"]
 
-        odb = self.index.odb_map.get(entry.key)
+        storage = self.index.storage_map.get(entry.key)
+        odb = storage.odb
         if odb:
             cache_path = odb.oid_to_path(value)
             if odb.fs.exists(cache_path):
                 return odb.fs, cache_path
 
-        remote = self.index.remote_map.get(entry.key)
+        remote = storage.remote
         if remote:
             remote_path = remote.oid_to_path(value)
             return remote.fs, remote_path

--- a/src/dvc_data/index/add.py
+++ b/src/dvc_data/index/add.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Optional
 
 from .build import build_entries, build_entry
+from .index import Storage
 
 if TYPE_CHECKING:
     from dvc_objects.fs import FileSystem
@@ -19,6 +20,8 @@ def add(
     entry = build_entry(path, fs)
     entry.key = key
     index.add(entry)
+
+    index.storage_map[key] = Storage(fs=fs, path=path)
 
     if not fs.isdir(path):
         return

--- a/src/dvc_data/index/build.py
+++ b/src/dvc_data/index/build.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional
 
 from ..hashfile.hash import hash_file
 from ..hashfile.meta import Meta
-from .index import DataIndex, DataIndexEntry
+from .index import DataIndex, DataIndexEntry, Storage
 
 if TYPE_CHECKING:
     from dvc_objects.fs.base import FileSystem
@@ -30,8 +30,6 @@ def build_entry(
     return DataIndexEntry(
         meta=meta,
         hash_info=hash_info,
-        path=path,
-        fs=fs,
     )
 
 
@@ -70,6 +68,8 @@ def build(
     path: str, fs: "FileSystem", ignore: Optional["Ignore"] = None
 ) -> DataIndex:
     index = DataIndex()
+
+    index.storage_map[()] = Storage(fs=fs, path=path)
 
     for entry in build_entries(path, fs, ignore=ignore):
         index.add(entry)

--- a/src/dvc_data/index/view.py
+++ b/src/dvc_data/index/view.py
@@ -13,7 +13,7 @@ from ..hashfile.tree import Tree
 from .index import BaseDataIndex, DataIndex, DataIndexEntry, DataIndexKey
 
 if TYPE_CHECKING:
-    from .index import ODBMapping
+    from .index import StorageMapping
 
 
 class DataIndexView(BaseDataIndex):
@@ -26,12 +26,8 @@ class DataIndexView(BaseDataIndex):
         self.filter_fn = filter_fn
 
     @property
-    def odb_map(self) -> "ODBMapping":  # type: ignore[override]
-        return self._index.odb_map
-
-    @property
-    def remote_map(self) -> "ODBMapping":  # type: ignore[override]
-        return self._index.remote_map
+    def storage_map(self) -> "StorageMapping":  # type: ignore[override]
+        return self._index.storage_map
 
     def __getitem__(self, key: DataIndexKey) -> DataIndexEntry:
         if self.filter_fn(key):


### PR DESCRIPTION
This replaces `odb_map` and `remote_map` in `DataIndex`, and `fs` and `path` in `DataIndexEntry` incorporating everything into `Storage`, which describes where to get the data contents from no matter how they are stored (just as plain backup in a directory or in an object storage).

`DataIndexEntry.fs/path` were very confusing, as it was not clear what they really represent and were often unecessarily used during different operations (for example `checkout` that mutates those instead of returning a new local index). This also removes unserializable `fs` instance from `DataIndexEntry`, making it much easier to work with after loading.

The new `Storage.fs/path` concepts fit nicely into dvc's import functionality, by giving a clear way to declare where to get the data from.

Related https://github.com/iterative/dvc/pull/8827