### PR TITLE
index: checkout: correctly modify index in place

### DIFF
--- a/src/dvc_data/index/checkout.py
+++ b/src/dvc_data/index/checkout.py
@@ -102,6 +102,11 @@ def checkout(
                 for entry, info in zip(entries, infos):
                     entry.meta = Meta.from_info(info, fs.protocol)
     # FIXME should return new index
+    for key in list(index.storage_map.keys()):
+        storage = index.storage_map[key]
+        storage.fs = fs
+        storage.path = fs.path.join(path, *key)
+        index.storage_map[key] = storage
     return transferred
 
 

--- a/src/dvc_data/index/checkout.py
+++ b/src/dvc_data/index/checkout.py
@@ -101,6 +101,7 @@ def checkout(
                 infos = fs.info(list(dest_paths), callback=cb, batch_size=jobs)
                 for entry, info in zip(entries, infos):
                     entry.meta = Meta.from_info(info, fs.protocol)
+                    index.add(entry)
     # FIXME should return new index
     for key in list(index.storage_map.keys()):
         storage = index.storage_map[key]

--- a/src/dvc_data/index/index.py
+++ b/src/dvc_data/index/index.py
@@ -165,7 +165,7 @@ class StorageMapping(MutableMapping):
         return None
 
     def __iter__(self):
-        yield from self._map.items()
+        yield from self._map.keys()
 
     def __len__(self):
         return len(self._map)

--- a/src/dvc_data/index/index.py
+++ b/src/dvc_data/index/index.py
@@ -10,7 +10,6 @@ from typing import (
     Dict,
     Iterable,
     Iterator,
-    Mapping,
     MutableMapping,
     Optional,
     Tuple,
@@ -171,7 +170,7 @@ class StorageMapping(MutableMapping):
         return len(self._map)
 
 
-class BaseDataIndex(ABC, Mapping[DataIndexKey, DataIndexEntry]):
+class BaseDataIndex(ABC, MutableMapping[DataIndexKey, DataIndexEntry]):
     storage_map: StorageMapping
 
     @abstractmethod
@@ -224,6 +223,9 @@ class BaseDataIndex(ABC, Mapping[DataIndexKey, DataIndexEntry]):
             ret[entry.hash_info.name] = entry.hash_info.value
 
         return ret
+
+    def add(self, entry: DataIndexEntry):
+        self[cast(DataIndexKey, entry.key)] = entry
 
     @abstractmethod
     def ls(self, root_key: DataIndexKey, detail=True):
@@ -294,9 +296,6 @@ class DataIndex(BaseDataIndex, MutableMapping[DataIndexKey, DataIndexEntry]):
 
     def __len__(self):
         return len(self._trie)
-
-    def add(self, entry: DataIndexEntry):
-        self[entry.key] = entry
 
     def _load(self, key, entry):
         if not entry:

--- a/src/dvc_data/index/view.py
+++ b/src/dvc_data/index/view.py
@@ -29,10 +29,22 @@ class DataIndexView(BaseDataIndex):
     def storage_map(self) -> "StorageMapping":  # type: ignore[override]
         return self._index.storage_map
 
+    def __setitem__(self, key, value):
+        if self.filter_fn(key):
+            self._index[key] = value
+        else:
+            raise KeyError
+
     def __getitem__(self, key: DataIndexKey) -> DataIndexEntry:
         if self.filter_fn(key):
             return self._index[key]
         raise KeyError
+
+    def __delitem__(self, key: DataIndexKey):
+        if self.filter_fn(key):
+            del self._index[key]
+        else:
+            raise KeyError
 
     def __iter__(self) -> Iterator[DataIndexKey]:
         return (key for key, _ in self._iteritems())


### PR DESCRIPTION
Ideally checkout shouldn't alter existing index, but rather return a new one instead. But this is something that we currently depend on, so I want to keep it working and change this behaviour later on.