### PR TITLE
index: get rid of DataIndexEntry.obj

### DIFF
--- a/src/dvc_data/fs.py
+++ b/src/dvc_data/fs.py
@@ -54,11 +54,11 @@ class DataFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
         entry = info["entry"]
 
         storage = self.index.storage_map.get(entry.key)
-        odb = storage.odb
-        if odb:
-            cache_path = odb.oid_to_path(value)
-            if odb.fs.exists(cache_path):
-                return odb.fs, cache_path
+        cache = storage.cache
+        if cache:
+            cache_path = cache.oid_to_path(value)
+            if cache.fs.exists(cache_path):
+                return cache.fs, cache_path
 
         remote = storage.remote
         if remote:

--- a/src/dvc_data/index/checkout.py
+++ b/src/dvc_data/index/checkout.py
@@ -72,7 +72,7 @@ def checkout(
             src_path = storage.path
         else:
             assert entry.hash_info
-            odb = storage.odb or storage.remote
+            odb = storage.odb or storage.cache or storage.remote
             assert odb
             src_fs = odb.fs
             src_path = odb.oid_to_path(entry.hash_info.value)

--- a/src/dvc_data/index/index.py
+++ b/src/dvc_data/index/index.py
@@ -131,9 +131,15 @@ def _try_load(
 class Storage:
     """Describes where the data contents could be found"""
 
+    # fs/path pair if we have the file stashed somewhere
     fs: Optional["FileSystem"] = None
     path: Optional[str] = None
+
+    # odb could be an in-memory one
     odb: Optional["HashFileDB"] = None
+    # cache is typically a localfs odb
+    cache: Optional["HashFileDB"] = None
+    # remote is typically a cloud odb
     remote: Optional["HashFileDB"] = None
 
 
@@ -316,7 +322,7 @@ class DataIndex(BaseDataIndex, MutableMapping[DataIndexKey, DataIndexEntry]):
         if not entry.obj:
             storage = self.storage_map.get(key)
             entry.obj = _try_load(
-                [storage.odb, storage.remote], entry.hash_info
+                [storage.odb, storage.cache, storage.remote], entry.hash_info
             )
 
         if not entry.obj:

--- a/src/dvc_data/index/save.py
+++ b/src/dvc_data/index/save.py
@@ -92,7 +92,6 @@ def _save_dir_entry(
     meta, tree = build_tree(index, key)
     tree = add_update_tree(cache, tree)
     entry.meta = meta
-    entry.obj = tree
     entry.hash_info = tree.hash_info
     assert tree.hash_info.name and tree.hash_info.value
     setattr(entry.meta, tree.hash_info.name, tree.hash_info.value)

--- a/src/dvc_data/index/save.py
+++ b/src/dvc_data/index/save.py
@@ -87,7 +87,7 @@ def _save_dir_entry(
     from ..hashfile.db import add_update_tree
 
     entry = index[key]
-    cache = odb or index.storage_map[key].odb
+    cache = odb or index.storage_map[key].cache
     assert cache
     meta, tree = build_tree(index, key)
     tree = add_update_tree(cache, tree)
@@ -140,7 +140,7 @@ def save(
             # version_id.
             path = fs.path.version_path(path, entry.meta.version_id)
         if entry.hash_info:
-            cache = odb or index.storage_map[key].odb
+            cache = odb or index.storage_map[key].cache
             assert cache
             assert entry.hash_info.value
             oid = entry.hash_info.value

--- a/tests/benchmarks/test_index.py
+++ b/tests/benchmarks/test_index.py
@@ -1,8 +1,0 @@
-from dvc_data.index import DataIndexEntry
-
-
-def test_entry(benchmark):
-    def _create_entry():
-        DataIndexEntry()
-
-    benchmark.pedantic(_create_entry, rounds=100000)

--- a/tests/benchmarks/test_index.py
+++ b/tests/benchmarks/test_index.py
@@ -1,0 +1,8 @@
+from dvc_data.index import DataIndexEntry
+
+
+def test_entry(benchmark):
+    def _create_entry():
+        DataIndexEntry()
+
+    benchmark.pedantic(_create_entry, rounds=100000)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -77,7 +77,7 @@ def test_fs(tmp_upath, odb, as_filesystem):
         }
     )
     index.storage_map = StorageMapping(
-        {("foo",): Storage(odb=odb), ("data",): Storage(odb=odb)}
+        {("foo",): Storage(cache=odb), ("data",): Storage(cache=odb)}
     )
     fs = DataFileSystem(index)
     assert fs.exists("foo")
@@ -211,7 +211,7 @@ def test_checkout(tmp_upath, odb, as_filesystem):
         }
     )
     index.storage_map = StorageMapping(
-        {("foo",): Storage(odb=odb), ("data",): Storage(odb=odb)}
+        {("foo",): Storage(cache=odb), ("data",): Storage(cache=odb)}
     )
     checkout(index, str(tmp_upath), as_filesystem(tmp_upath.fs))
     assert (tmp_upath / "foo").read_text() == "foo\n"
@@ -303,7 +303,7 @@ def test_view_iteritems(odb, keys, filter_fn, ensure_loaded):
             ),
         }
     )
-    index.storage_map = StorageMapping({("dir",): Storage(odb=odb)})
+    index.storage_map = StorageMapping({("dir",): Storage(cache=odb)})
     index_view = view(index, filter_fn)
     assert keys == {
         key for key, _ in index_view._iteritems(ensure_loaded=ensure_loaded)
@@ -330,7 +330,7 @@ def test_view(odb):
             expected_key: expected_entry,
         }
     )
-    index.storage_map = StorageMapping({("dir",): Storage(odb=odb)})
+    index.storage_map = StorageMapping({("dir",): Storage(cache=odb)})
     index_view = view(index, lambda k: "dir" in k)
     assert {expected_key} == set(index_view.keys())
     assert expected_key in index_view
@@ -359,7 +359,7 @@ def test_view_ls(odb):
             ),
         }
     )
-    index.storage_map = StorageMapping({("dir",): Storage(odb=odb)})
+    index.storage_map = StorageMapping({("dir",): Storage(cache=odb)})
     index_view = view(index, lambda k: "dir" in k)
     assert list(index_view.ls((), detail=False)) == [("dir",)]
     assert list(index_view.ls(("dir",), detail=False)) == [
@@ -389,7 +389,7 @@ def test_view_traverse(odb):
             ),
         }
     )
-    index.storage_map = StorageMapping({("dir",): Storage(odb=odb)})
+    index.storage_map = StorageMapping({("dir",): Storage(cache=odb)})
     index_view = view(index, lambda k: "dir" in k)
 
     keys = []


### PR DESCRIPTION
Similar to already removed fs/path/odb/remote, this just doesn't belong here
and should be handled through `storage.odb`/`entry.hash_info` combo.

This marks the last unserializable field in DataIndexEntry 🎉 

Related to https://github.com/iterative/dvc/pull/8827