### PR TITLE
index: checkout: don't use storage.odb

### DIFF
--- a/src/dvc_data/index/checkout.py
+++ b/src/dvc_data/index/checkout.py
@@ -93,7 +93,7 @@ def checkout(  # noqa: C901
             src_path = storage.path
         else:
             assert entry.hash_info
-            odb = storage.odb or storage.cache or storage.remote
+            odb = storage.cache or storage.remote
             assert odb
             src_fs = odb.fs
             src_path = odb.oid_to_path(entry.hash_info.value)


### PR DESCRIPTION
Checkout wants to be able to use links most of the time, so there is really no reason to use in-memory odb for now.

Leftover from https://github.com/iterative/dvc-data/pull/304

Required for https://github.com/iterative/dvc/pull/8989