### PR TITLE
index: support loading from Tree objects serialized with meta

### DIFF
--- a/src/dvc_data/hashfile/tree.py
+++ b/src/dvc_data/hashfile/tree.py
@@ -158,7 +158,7 @@ class Tree(HashFile):
         return tree
 
     @classmethod
-    def load(cls, odb, hash_info) -> "Tree":
+    def load(cls, odb, hash_info, hash_name: Optional[str] = None) -> "Tree":
         obj = odb.get(hash_info.value)
 
         try:
@@ -174,7 +174,7 @@ class Tree(HashFile):
             )
             raise ObjectFormatError(f"{obj} is corrupted")
 
-        tree = cls.from_list(raw)
+        tree = cls.from_list(raw, hash_name=hash_name)
         tree.path = obj.path
         tree.fs = obj.fs
         tree.hash_info = hash_info

--- a/src/dvc_data/hashfile/tree.py
+++ b/src/dvc_data/hashfile/tree.py
@@ -70,13 +70,13 @@ class Tree(HashFile):
     ) -> Optional[Tuple[Optional["Meta"], "HashInfo"]]:
         return self._dict.get(key, default)
 
-    def digest(self):
+    def digest(self, with_meta: bool = False):
         from dvc_objects.fs import MemoryFileSystem
         from dvc_objects.fs.utils import tmp_fname
 
         memfs = MemoryFileSystem()
         path = "memory://{}".format(tmp_fname(""))
-        memfs.pipe_file(path, self.as_bytes())
+        memfs.pipe_file(path, self.as_bytes(with_meta=with_meta))
         self.fs = memfs
         self.path = path
         _, self.hash_info = hash_file(path, memfs, "md5")
@@ -135,8 +135,10 @@ class Tree(HashFile):
             key=itemgetter(self.PARAM_RELPATH),
         )
 
-    def as_bytes(self):
-        return json.dumps(self.as_list(), sort_keys=True).encode("utf-8")
+    def as_bytes(self, with_meta: bool = False):
+        return json.dumps(
+            self.as_list(with_meta=with_meta), sort_keys=True
+        ).encode("utf-8")
 
     @classmethod
     def from_list(cls, lst, hash_name: Optional[str] = None):

--- a/src/dvc_data/index/index.py
+++ b/src/dvc_data/index/index.py
@@ -119,7 +119,7 @@ def _try_load(
             continue
 
         try:
-            return Tree.load(odb, hash_info)
+            return Tree.load(odb, hash_info, hash_name="md5")
         except (FileNotFoundError, ObjectFormatError):
             pass
 


### PR DESCRIPTION
The tree objects that we build for cloud versioning have to have meta in them, so we have to be able to load our index using those objects.

Required for https://github.com/iterative/dvc/pull/8989