### PR TITLE
index: introduce storage.remote_fs/path

### DIFF
--- a/src/dvc_data/index/index.py
+++ b/src/dvc_data/index/index.py
@@ -133,6 +133,8 @@ class Storage:
     # fs/path pair if we have the file stashed somewhere
     fs: Optional["FileSystem"] = None
     path: Optional[str] = None
+    remote_fs: Optional["FileSystem"] = None
+    remote_path: Optional[str] = None
 
     # odb could be an in-memory one
     odb: Optional["HashFileDB"] = None


### PR DESCRIPTION
We have `storage.remote` already, which is an odb, but we need an equivalent for cloud versioning.

Related https://github.com/iterative/dvc/pull/8962