### PR TITLE
index: settle storage layout/operations

### DIFF
--- a/src/dvc_data/fs.py
+++ b/src/dvc_data/fs.py
@@ -53,14 +53,13 @@ class DataFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
 
         entry = info["entry"]
 
-        storage = self.index.storage_map.get(entry.key)
-        cache = storage.cache
+        cache = self.index.storage_map.get_cache_odb(entry)
         if cache:
             cache_path = cache.oid_to_path(value)
             if cache.fs.exists(cache_path):
                 return cache.fs, cache_path
 
-        remote = storage.remote
+        remote = self.index.storage_map.get_remote_odb(entry)
         if remote:
             remote_path = remote.oid_to_path(value)
             return remote.fs, remote_path

--- a/src/dvc_data/index/add.py
+++ b/src/dvc_data/index/add.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Optional
 
 from .build import build_entries, build_entry
-from .index import Storage
+from .index import FileStorage
 
 if TYPE_CHECKING:
     from dvc_objects.fs import FileSystem
@@ -21,7 +21,7 @@ def add(
     entry.key = key
     index.add(entry)
 
-    index.storage_map[key] = Storage(fs=fs, path=path)
+    index.storage_map.add_data(FileStorage(key=key, fs=fs, path=path))
 
     if not fs.isdir(path):
         return

--- a/src/dvc_data/index/build.py
+++ b/src/dvc_data/index/build.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional
 
 from ..hashfile.hash import hash_file
 from ..hashfile.meta import Meta
-from .index import DataIndex, DataIndexEntry, Storage
+from .index import DataIndex, DataIndexEntry, FileStorage
 
 if TYPE_CHECKING:
     from dvc_objects.fs.base import FileSystem
@@ -69,7 +69,7 @@ def build(
 ) -> DataIndex:
     index = DataIndex()
 
-    index.storage_map[()] = Storage(fs=fs, path=path)
+    index.storage_map.add_data(FileStorage(key=(), fs=fs, path=path))
 
     for entry in build_entries(path, fs, ignore=ignore):
         index.add(entry)


### PR DESCRIPTION
This does a few things:

1) partitions storage into 3 categories:
    * `data` - immediately accessible data contents (e.g. right in your workspace)
    * `cache` - data contents stashed somewhere aside
    * `remote` - data contents stoshed remotely (kinda like cold cache)

2) makes so that each storage can be either object-based (our typical odbs) or
    filesystem-based (e.g. cloud versioning or just a plain old backup copy).

3) settles `save` convention as being a transfer of data contents from `data`
    storage (e.g. workspace) to `cache` storage. But also allows to pick other
    storage type to get the data from (e.g. `remote`, which is how we use it
    for cloud-versioning)

4) settles `checkout` convention as being a transfer of data contents from `cache`,
    but also allows one to pick other storage type to get the data from (e.g. `data`,
    which is how we use it for cloud-versioning, or `remote` for cases where having a
    an intermediate cache is undesirable).

These things will simplify our current cloud-versioning operations and will also allow us to introduce `dvcfs` support (which also means `dvc.api` support) for it (coming in a separate PR later). Also this allows us to use persistent index with `FileStorage` in https://github.com/iterative/dvc/pull/8962 (again coming in a separate PR).

Not totally happy with the code itself (esp around StorageMapping) and that will be settled later on, but it goes in the correct direction.