### PR TITLE
deps: use version ranges for subpackages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,11 +28,11 @@ install_requires=
     dictdiffer>=0.8.1
     pygtrie>=2.3.2
     shortuuid>=0.5.0
-    dvc-objects==0.19.3
+    dvc-objects>=0.19.3,<1
     diskcache>=5.2.1
     nanotime>=0.5.2
     attrs>=21.3.0
-    sqltrie==0.0.28
+    sqltrie>=0.0.28,<1
 
 [options.extras_require]
 cli =


### PR DESCRIPTION
Should simplify conda releases and allows bumping dvc-objects without requiring bumped dvc-data release

- Unpins `dvc-objects` and `sqltrie` versions (with capped major ver)

related: https://github.com/iterative/dvc/pull/9056