### PR TITLE
hashfile: build: handle broken symlink or TreeError

### DIFF
--- a/src/dvc_data/hashfile/build.py
+++ b/src/dvc_data/hashfile/build.py
@@ -150,6 +150,11 @@ def _build_tree(
                 tree_meta.size += meta.size or 0
                 tree_meta.nfiles += 1
 
+    if not tree_meta.nfiles:
+        # This will raise FileNotFoundError if it is a
+        # broken symlink or TreeError
+        next(iter(fs.ls(path)))
+
     tree.digest()
     tree = add_update_tree(odb, tree)
     return tree_meta, tree


### PR DESCRIPTION
This happens when a directory exists (e.g. os.lexists() is True) but any attempt at looking into it results in `FileNotFoundError` because either the symlink is broken or, in datafs, we don't have the info about the dir which results in `TreeError` which is equivalent to a broken symlink.

Found these while working on https://github.com/iterative/dvc/issues/8789