### PR TITLE
index: try loading missing meta from file storage

### DIFF
--- a/src/dvc_data/hashfile/meta.py
+++ b/src/dvc_data/hashfile/meta.py
@@ -4,7 +4,7 @@ from attrs import define, field, fields_dict
 from dvc_objects.fs.utils import is_exec
 
 
-@define
+@define(hash=True)
 class Meta:
     PARAM_ISDIR: ClassVar[str] = "isdir"
     PARAM_SIZE: ClassVar[str] = "size"

--- a/tests/index/test_diff.py
+++ b/tests/index/test_diff.py
@@ -18,6 +18,7 @@ def test_diff():
     old_foo_key = ("foo",)
     old_foo_entry = DataIndexEntry(
         key=old_foo_key,
+        meta=Meta(),
         hash_info=HashInfo(
             name="md5", value="d3b07384d113edec49eaa6238ad5ff00"
         ),
@@ -25,6 +26,7 @@ def test_diff():
     old_bar_key = ("dir", "subdir", "bar")
     old_bar_entry = DataIndexEntry(
         key=old_bar_key,
+        meta=Meta(isdir=True),
         hash_info=HashInfo(
             name="md5",
             value="1f69c66028c35037e8bf67e5bc4ceb6a.dir",
@@ -44,6 +46,7 @@ def test_diff():
     new_foo_key = ("data", "FOO")
     new_foo_entry = DataIndexEntry(
         key=new_foo_key,
+        meta=Meta(),
         hash_info=HashInfo(
             name="md5", value="d3b07384d113edec49eaa6238ad5ff00"
         ),

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -104,7 +104,6 @@ def test_fs_file_storage(tmp_upath, as_filesystem):
             ),
             ("data",): DataIndexEntry(
                 key=("data",),
-                meta=Meta(isdir=True),
             ),
         }
     )
@@ -114,8 +113,13 @@ def test_fs_file_storage(tmp_upath, as_filesystem):
     fs = DataFileSystem(index)
     assert fs.exists("foo")
     assert fs.cat("foo") == b"foo\n"
-    assert fs.ls("/", detail=False) == ["/foo", "/data"]
-    assert fs.ls("/", detail=True) == [fs.info("/foo"), fs.info("/data")]
+    assert sorted(fs.ls("/", detail=False)) == sorted(["/foo", "/data"])
+    assert sorted(
+        fs.ls("/", detail=True), key=lambda entry: entry["name"]
+    ) == sorted(
+        [fs.info("/foo"), fs.info("/data")],
+        key=lambda entry: entry["name"],
+    )
     assert fs.cat("/data/bar") == b"bar\n"
     assert fs.cat("/data/baz") == b"baz\n"
     assert sorted(fs.ls("/data", detail=False)) == sorted(


### PR DESCRIPTION
Happens when we've backed out our data to data storage but we are not sure if it is a directory or a file.

Related https://github.com/iterative/dvc/issues/8789