### PR TITLE
hashfile.tree: implement update_tree

### DIFF
--- a/src/dvc_data/hashfile/tree.py
+++ b/src/dvc_data/hashfile/tree.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import posixpath
-from typing import TYPE_CHECKING, Dict, Final, Iterable, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, Final, Iterable, List, Optional, Tuple
 
 from dvc_objects.errors import ObjectFormatError
 from funcy import cached_property
@@ -354,3 +354,20 @@ def update_meta(ours: "Tree", theirs: "Tree") -> "Tree":
     updated.hash_info = ours.hash_info
     updated.oid = ours.oid
     return updated
+
+
+def update_tree(
+    tree: "Tree",
+    update: Dict[Tuple[str, ...], Tuple[Optional["Meta"], "HashInfo"]],
+    remove: List[Tuple[str, ...]],
+) -> "Tree":
+    d = tree.as_dict()
+    d.update(update)
+    for item in remove:
+        d.pop(item)
+
+    new_tree = Tree()
+    new_tree._dict = d  # pylint: disable=protected-access
+    new_tree.fs = tree.fs
+    new_tree.digest()
+    return new_tree


### PR DESCRIPTION
I am still thinking of what the high-level API should be for building these upserted files.

We need a way to build the files, with possible expansion of directories/prefixes and ignores applied. Also, would be nice to have a batched build functionality. 

But since, `build()` is already complicated, I'm still thinking of other options for now.
So, I have only created a low-level helper to update a tree.

Related to https://github.com/iterative/dvc/issues/4657.