### PR TITLE
fs: get rid of isout/isdvc

### DIFF
--- a/src/dvc_data/fs.py
+++ b/src/dvc_data/fs.py
@@ -109,18 +109,6 @@ class DataFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
         except TreeError as exc:
             raise FileNotFoundError from exc
 
-    def isdvc(self, path, recursive=False):
-        try:
-            info = self.info(path)
-        except FileNotFoundError:
-            return False
-
-        if not recursive:
-            return info.get("isout")
-
-        key = self._get_key(path)
-        return self.index.has_node(key)
-
     def info(self, path, **kwargs):
         key = self._get_key(path)
         info = self.index.info(key)

--- a/src/dvc_data/index/index.py
+++ b/src/dvc_data/index/index.py
@@ -425,8 +425,6 @@ class BaseDataIndex(ABC, MutableMapping[DataIndexKey, DataIndexEntry]):
                 "type": "directory",
                 "size": 0,
                 "isexec": False,
-                "isdvc": bool(self.longest_prefix(key)),
-                "isout": False,
                 "entry": None,
             }
 
@@ -440,8 +438,6 @@ class BaseDataIndex(ABC, MutableMapping[DataIndexKey, DataIndexEntry]):
             "type": "directory" if isdir else "file",
             "size": meta.size if meta else 0,
             "isexec": meta.isexec if meta else False,
-            "isdvc": True,
-            "isout": True,
             "entry": entry,
         }
 


### PR DESCRIPTION
These are legacy things that are very fragile and confusing. The definition of both is very murky, but it is clear that both just don't belong in dvc-data.

Run into these while working on https://github.com/iterative/dvc/pull/9444 where they broke.