### PR TITLE
index: checkout: ignore dir deletion errors

### DIFF
--- a/src/dvc_data/index/checkout.py
+++ b/src/dvc_data/index/checkout.py
@@ -197,7 +197,10 @@ def _create_files(  # noqa: C901
 
 def _delete_dirs(entries, path, fs):
     for entry in entries:
-        fs.rmdir(fs.path.join(path, *entry.key))
+        try:
+            fs.rmdir(fs.path.join(path, *entry.key))
+        except OSError:
+            pass
 
 
 def _create_dirs(entries, path, fs):


### PR DESCRIPTION
This might be a "Directory not empty" in case the dir contains files not tracked by dvc or something else, but it shouldn't stop us from creating files.

Fixes https://github.com/iterative/dvc/issues/9566