### PR TITLE
index: fetch: cache collected files

### DIFF
--- a/src/dvc_data/index/index.py
+++ b/src/dvc_data/index/index.py
@@ -567,9 +567,11 @@ class DataIndex(BaseDataIndex, MutableMapping[DataIndexKey, DataIndexEntry]):
         return ret
 
     def view(self, key):
+        import copy
+
         ret = DataIndex()
         ret._trie = self._trie.view(key)  # pylint: disable=protected-access
-        ret.storage_map = self.storage_map
+        ret.storage_map = copy.deepcopy(self.storage_map)
         return ret
 
     def commit(self):


### PR DESCRIPTION
`dvc fetch` noop in `dvc-bench` goes from ~30sec down to ~10sec for me.

Next step is to also cache remote index, so we don't have to waste those ~10sec checking files in the remote.

Fixes #375 