### PR TITLE
index: fetch: use entry.loaded when collecting fs_index

### DIFF
--- a/src/dvc_data/index/fetch.py
+++ b/src/dvc_data/index/fetch.py
@@ -66,6 +66,7 @@ def _collect_from_index(
                 key=storage_key,
                 meta=entry.meta,
                 hash_info=entry.hash_info,
+                loaded=entry.loaded,
             )
 
     except KeyError:


### PR DESCRIPTION
This avoids reloading the index when used later on.

Related https://github.com/iterative/dvc/pull/9579