### PR TITLE
index: checkout: split into compare and apply

### DIFF
--- a/src/dvc_data/index/__init__.py
+++ b/src/dvc_data/index/__init__.py
@@ -1,6 +1,5 @@
 from .add import add  # noqa: F401, pylint: disable=unused-import
 from .build import build  # noqa: F401, pylint: disable=unused-import
-from .checkout import checkout  # noqa: F401, pylint: disable=unused-import
 from .diff import diff  # noqa: F401, pylint: disable=unused-import
 from .fetch import fetch  # noqa: F401, pylint: disable=unused-import
 from .index import *  # noqa: F401,F403, pylint: disable=unused-import

--- a/src/dvc_data/index/fetch.py
+++ b/src/dvc_data/index/fetch.py
@@ -7,7 +7,7 @@ from dvc_data.hashfile.db import get_index
 from dvc_data.hashfile.transfer import transfer
 
 from .build import build
-from .checkout import checkout
+from .checkout import apply, compare
 from .index import (
     DataIndex,
     DataIndexEntry,
@@ -200,13 +200,13 @@ def _fetch(
                 )
             else:
                 old = build(cache.path, cache.fs)
-                checkout_stats = checkout(
-                    fs_index,
+                diff = compare(old, fs_index)
+                checkout_stats = apply(
+                    diff,
                     cache.path,
                     cache.fs,
                     update_meta=False,
                     storage="remote",
-                    old=old,
                     jobs=jobs,
                     callback=cb,
                 )

--- a/tests/index/test_checkout.py
+++ b/tests/index/test_checkout.py
@@ -1,6 +1,7 @@
 from dvc_data.hashfile.hash_info import HashInfo
 from dvc_data.hashfile.meta import Meta
-from dvc_data.index import DataIndex, DataIndexEntry, ObjectStorage, checkout
+from dvc_data.index import DataIndex, DataIndexEntry, ObjectStorage
+from dvc_data.index.checkout import apply, compare
 
 
 def test_checkout(tmp_upath, odb, as_filesystem):
@@ -24,7 +25,8 @@ def test_checkout(tmp_upath, odb, as_filesystem):
         }
     )
     index.storage_map.add_cache(ObjectStorage((), odb))
-    checkout(index, str(tmp_upath), as_filesystem(tmp_upath.fs))
+    diff = compare(None, index)
+    apply(diff, str(tmp_upath), as_filesystem(tmp_upath.fs))
     assert (tmp_upath / "foo").read_text() == "foo\n"
     assert (tmp_upath / "data").is_dir()
     assert (tmp_upath / "data" / "bar").read_text() == "bar\n"
@@ -52,5 +54,6 @@ def test_checkout_file(tmp_upath, odb, as_filesystem):
         }
     )
     index.storage_map.add_cache(ObjectStorage((), odb))
-    checkout(index, str(tmp_upath / "foo"), as_filesystem(tmp_upath.fs))
+    diff = compare(None, index)
+    apply(diff, str(tmp_upath / "foo"), as_filesystem(tmp_upath.fs))
     assert (tmp_upath / "foo").read_text() == "foo\n"

--- a/tests/index/test_index.py
+++ b/tests/index/test_index.py
@@ -1,5 +1,6 @@
 import pytest
 
+import dvc_data.index.checkout as checkout
 from dvc_data.fs import DataFileSystem
 from dvc_data.hashfile.hash_info import HashInfo
 from dvc_data.hashfile.meta import Meta
@@ -10,7 +11,6 @@ from dvc_data.index import (
     ObjectStorage,
     add,
     build,
-    checkout,
     fetch,
     md5,
     read_db,
@@ -210,8 +210,9 @@ def test_fetch(tmp_upath, make_odb, odb, as_filesystem):
 
     (tmp_upath / "fetched").mkdir()
     fetch([index])  # , str(tmp_upath / "fetched"))
-    checkout(
-        index,
+    diff = checkout.compare(None, index)
+    checkout.apply(
+        diff,
         str(tmp_upath / "checkout"),
         as_filesystem(tmp_upath.fs),
         storage="cache",


### PR DESCRIPTION
checkout is an overloaded term that does too much in our case (just look at the number of arguments we pass to it). We have clear separate stages within it these days and so can split it up to be less overloaded and easier to use when need to indicate progress to users.

The flag separation is not the cleanest right now and will need some work in the near future (e.g. why not check cache during `compare` stage to know what we can delete and not wait until trying to `apply` changes), but it is still an improvement as is.

Per https://github.com/iterative/dvc-data/pull/373#discussion_r1225675804 and similar to https://github.com/iterative/dvc-data/pull/389