### PR TITLE
Add trace to transfer code

### DIFF
--- a/src/dvc_data/hashfile/transfer.py
+++ b/src/dvc_data/hashfile/transfer.py
@@ -89,6 +89,10 @@ def _do_transfer(
         bound_file_ids = all_file_ids & entry_ids
         all_file_ids -= entry_ids
 
+        logger.trace(
+            f"transfer dir: {dir_hash} with {len(bound_file_ids)} files"
+        )
+
         dir_fails = _add(src, dest, bound_file_ids, **kwargs)
         if dir_fails:
             logger.debug(

--- a/src/dvc_data/hashfile/transfer.py
+++ b/src/dvc_data/hashfile/transfer.py
@@ -151,6 +151,7 @@ def _add(
     hash_infos: Iterable["HashInfo"],
     **kwargs,
 ) -> Set["HashInfo"]:
+
     failed: Set["HashInfo"] = set()
     if not hash_infos:
         return failed

--- a/src/dvc_data/hashfile/transfer.py
+++ b/src/dvc_data/hashfile/transfer.py
@@ -90,7 +90,7 @@ def _do_transfer(
         all_file_ids -= entry_ids
 
         logger.trace(
-            f"transfer dir: {dir_hash} with {len(bound_file_ids)} files"
+            "transfer dir: %s with %d files", dir_hash, len(bound_file_ids)
         )
 
         dir_fails = _add(src, dest, bound_file_ids, **kwargs)

--- a/src/dvc_data/hashfile/transfer.py
+++ b/src/dvc_data/hashfile/transfer.py
@@ -89,7 +89,7 @@ def _do_transfer(
         bound_file_ids = all_file_ids & entry_ids
         all_file_ids -= entry_ids
 
-        logger.trace(
+        logger.debug(
             "transfer dir: %s with %d files", dir_hash, len(bound_file_ids)
         )
 
@@ -151,7 +151,6 @@ def _add(
     hash_infos: Iterable["HashInfo"],
     **kwargs,
 ) -> Set["HashInfo"]:
-
     failed: Set["HashInfo"] = set()
     if not hash_infos:
         return failed


### PR DESCRIPTION
In the middle of a rather large `dvc push` I noticed that dvc seemed to be hanging, it wasn't, but it also wasn't producing any output for hours. After some debugging I found that the slow bit of code is in the `_add`, and I added a tracing statement above it so if the user runs with `-vv` they can at least see that DVC is indeed doing something.  