### PR TITLE
index: introduce basic onerror

### DIFF
--- a/src/dvc_data/fs.py
+++ b/src/dvc_data/fs.py
@@ -89,7 +89,7 @@ class DataFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
         return fs.open(fspath, mode=mode, encoding=encoding)
 
     def ls(self, path, detail=True, **kwargs):
-        from .index import TreeError
+        from .index import DataIndexDirError
 
         root_key = self._get_key(path)
         try:
@@ -108,7 +108,7 @@ class DataFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
                 info["name"] = self.path.join(path, key[-1])
                 entries.append(info)
             return entries
-        except (KeyError, TreeError) as exc:
+        except (KeyError, DataIndexDirError) as exc:
             raise FileNotFoundError(
                 errno.ENOENT, os.strerror(errno.ENOENT), path
             ) from exc

--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -9,8 +9,7 @@ if TYPE_CHECKING:
     from .hashfile.hash_info import HashInfo
     from .index import BaseDataIndex, DataIndexKey
 
-from ..hashfile.tree import TreeError
-from .index import DataIndexEntry
+from .index import DataIndexDirError, DataIndexEntry
 
 ADD = "add"
 MODIFY = "modify"
@@ -151,7 +150,7 @@ def _get_items(
             items = dict(index.ls(key, detail=True))
     except KeyError:
         pass
-    except TreeError:
+    except DataIndexDirError:
         unknown = with_unknown
 
     return items, unknown

--- a/tests/index/test_index.py
+++ b/tests/index/test_index.py
@@ -110,6 +110,73 @@ def test_fs_file_storage(tmp_upath, as_filesystem):
     )
 
 
+def test_fs_broken(tmp_upath, odb, as_filesystem):
+    index = DataIndex(
+        {
+            ("foo",): DataIndexEntry(
+                key=("foo",),
+                hash_info=HashInfo(
+                    name="md5", value="d3b07384d113edec49eaa6238ad5ff00"
+                ),
+            ),
+            ("data",): DataIndexEntry(
+                key=("data",),
+                meta=Meta(isdir=True),
+                hash_info=HashInfo(
+                    name="md5",
+                    value="1f69c66028c35037e8bf67e5bc4ceb6a.dir",
+                ),
+            ),
+            ("broken",): DataIndexEntry(
+                key=("broken",),
+                meta=Meta(isdir=True),
+                hash_info=HashInfo(
+                    name="md5",
+                    value="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.dir",
+                ),
+            ),
+        }
+    )
+    index.storage_map.add_cache(ObjectStorage((), odb))
+    fs = DataFileSystem(index)
+    assert fs.exists("foo")
+    assert fs.cat("foo") == b"foo\n"
+    with pytest.raises(NotADirectoryError):
+        fs.ls("foo")
+
+    assert fs.ls("/", detail=False) == ["/foo", "/data", "/broken"]
+    assert fs.ls("/", detail=True) == [
+        fs.info("/foo"),
+        fs.info("/data"),
+        fs.info("/broken"),
+    ]
+
+    assert fs.cat("/data/bar") == b"bar\n"
+    assert fs.cat("/data/baz") == b"baz\n"
+    with pytest.raises(NotADirectoryError):
+        fs.ls("/data/bar")
+    assert fs.ls("/data", detail=False) == ["/data/bar", "/data/baz"]
+    assert fs.ls("/data", detail=True) == [
+        fs.info("/data/bar"),
+        fs.info("/data/baz"),
+    ]
+
+    assert fs.exists("/broken")
+    assert fs.isdir("/broken")
+    with pytest.raises(FileNotFoundError):
+        fs.ls("/broken", detail=False)
+
+    with pytest.raises(FileNotFoundError):
+        fs.ls("/broken", detail=True)
+
+    def onerror(_entry, _exc):
+        pass
+
+    fs.index.onerror = onerror
+    assert fs.ls("/broken", detail=False) == []
+    assert fs.ls("/broken", detail=True) == []
+
+
 def test_md5(tmp_upath, odb, as_filesystem):
     (tmp_upath / "foo").write_bytes(b"foo\n")
     (tmp_upath / "data").mkdir()


### PR DESCRIPTION
Also fixes legacy TreeError/DataIndexError mess and doesn't mark directories that we've failed to load as loaded in cache, preventing cache corruption.

Kudos @dberenbaum for investigation.

Note that behaviour in https://github.com/iterative/dvc/issues/9785 is not fixed by this, because it is more related to how we treat this error in datafs, dvcfs and also how fsspec's `fs.walk()` ignores broken directories. So we will look into maybe raising `DataIndexDirError` instead of treating it as a broken directory and ignoring in `datafs/dvcfs.ls`.

Fixes #413
Related https://github.com/iterative/dvc/issues/9785
Related https://github.com/iterative/studio/pull/6541