### PR TITLE
datafs: ls: pass DataIndexDirError through

### DIFF
--- a/src/dvc_data/fs.py
+++ b/src/dvc_data/fs.py
@@ -89,7 +89,6 @@ class DataFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
         return fs.open(fspath, mode=mode, encoding=encoding)
 
     def ls(self, path, detail=True, **kwargs):
-        from .index import DataIndexDirError
 
         root_key = self._get_key(path)
         try:
@@ -108,7 +107,7 @@ class DataFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
                 info["name"] = self.path.join(path, key[-1])
                 entries.append(info)
             return entries
-        except (KeyError, DataIndexDirError) as exc:
+        except KeyError as exc:
             raise FileNotFoundError(
                 errno.ENOENT, os.strerror(errno.ENOENT), path
             ) from exc

--- a/tests/index/test_index.py
+++ b/tests/index/test_index.py
@@ -6,6 +6,7 @@ from dvc_data.hashfile.hash_info import HashInfo
 from dvc_data.hashfile.meta import Meta
 from dvc_data.index import (
     DataIndex,
+    DataIndexDirError,
     DataIndexEntry,
     FileStorage,
     ObjectStorage,
@@ -163,10 +164,10 @@ def test_fs_broken(tmp_upath, odb, as_filesystem):
 
     assert fs.exists("/broken")
     assert fs.isdir("/broken")
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(DataIndexDirError):
         fs.ls("/broken", detail=False)
 
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(DataIndexDirError):
         fs.ls("/broken", detail=True)
 
     def onerror(_entry, _exc):


### PR DESCRIPTION
So far there doesn't seem to be a need to ignore this error in fs related code, so just passing it through without a way to configure it through `ls`.

Will need a corresponding fix on dvc's side in a separate PR. We will need to ignore it in index-related stuff like `dvc fetch`.

Related https://github.com/iterative/dvc/issues/9785