### PR TITLE
hashfile.utils.to_nanoseconds: use int instead of float to multiply

### DIFF
--- a/src/dvc_data/hashfile/utils.py
+++ b/src/dvc_data/hashfile/utils.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 
 def to_nanoseconds(ts: float) -> int:
-    return round(ts * 1e9)
+    return round(ts * 1_000_000_000)
 
 
 def get_mtime_and_size(


### PR DESCRIPTION
To avoid potential differences between float multiplications/integer multiplications. I want to preserve compatibility with nanotime as possible.