### PR TITLE
index: fetch: check connection before downloading

### DIFF
--- a/src/dvc_data/index/fetch.py
+++ b/src/dvc_data/index/fetch.py
@@ -53,6 +53,16 @@ def fetch(
         else:
             cb = callback
 
+        try:
+            # NOTE: make sure there are no auth errors
+            data.fs.exists(data.path)
+        except Exception:  # pylint: disable=W0703
+            failed += len(fs_index)
+            logger.exception(
+                f"failed to connect to {data.fs.protocol} ({data.path})"
+            )
+            continue
+
         with cb:
             if isinstance(cache, ObjectStorage) and isinstance(
                 data, ObjectStorage


### PR DESCRIPTION
Just a dirty trick to make sure we don't have any weird auth errors that will get in the way later on.

Ideally we should wrap the whole fetching logic and do as much as we can and only then raise, but this might resolve 99% potential problems for now. We can revisit this later.

Related https://github.com/iterative/studio/pull/6541