### PR TITLE
index: diff: reraise DataIndexTreeError if not with_unknown

### DIFF
--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -151,6 +151,8 @@ def _get_items(
     except KeyError:
         pass
     except DataIndexDirError:
+        if not with_unknown:
+            raise
         unknown = with_unknown
 
     return items, unknown


### PR DESCRIPTION
We now have `index.onerror` to ignore that if needed.

Related https://github.com/iterative/dvc/issues/9733