### PR TITLE
index: checkout: don't create broken directories

### DIFF
--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -38,7 +38,7 @@ class Change:
             entry = self.old or self.new
 
         assert entry
-        assert entry.key
+        assert entry.key is not None
         return entry.key
 
     def __bool__(self):

--- a/tests/index/test_checkout.py
+++ b/tests/index/test_checkout.py
@@ -57,3 +57,49 @@ def test_checkout_file(tmp_upath, odb, as_filesystem):
     diff = compare(None, index)
     apply(diff, str(tmp_upath / "foo"), as_filesystem(tmp_upath.fs))
     assert (tmp_upath / "foo").read_text() == "foo\n"
+
+
+def test_checkout_broken_dir(tmp_upath, odb, as_filesystem):
+    index = DataIndex(
+        {
+            ("foo",): DataIndexEntry(
+                key=("foo",),
+                meta=Meta(),
+                hash_info=HashInfo(
+                    name="md5", value="d3b07384d113edec49eaa6238ad5ff00"
+                ),
+            ),
+            ("data",): DataIndexEntry(
+                key=("data",),
+                meta=Meta(isdir=True),
+                hash_info=HashInfo(
+                    name="md5",
+                    value="1f69c66028c35037e8bf67e5bc4ceb6a.dir",
+                ),
+            ),
+            ("broken",): DataIndexEntry(
+                key=("broken",),
+                meta=Meta(isdir=True),
+                hash_info=HashInfo(
+                    name="md5",
+                    value="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.dir",
+                ),
+            ),
+        }
+    )
+    index.storage_map.add_cache(ObjectStorage((), odb))
+    diff = compare(None, index)
+    apply(diff, str(tmp_upath), as_filesystem(tmp_upath.fs))
+    assert (tmp_upath / "foo").read_text() == "foo\n"
+    assert (tmp_upath / "data").is_dir()
+    assert (tmp_upath / "data" / "bar").read_text() == "bar\n"
+    assert (tmp_upath / "data" / "baz").read_text() == "baz\n"
+    assert set(tmp_upath.iterdir()) == {
+        (tmp_upath / "foo"),
+        (tmp_upath / "data"),
+    }
+    assert set((tmp_upath / "data").iterdir()) == {
+        (tmp_upath / "data" / "bar"),
+        (tmp_upath / "data" / "baz"),
+    }
+    assert not (tmp_upath / "broken").exists()


### PR DESCRIPTION
If some directory is missing its cache and we can't restore it, we should just not create it at all instead of trying to create an empty directory.

Related https://github.com/iterative/dvc/issues/9733