### PR TITLE
index: checkout: handle possibly existing dirs with broken new dirs

### DIFF
--- a/src/dvc_data/index/checkout.py
+++ b/src/dvc_data/index/checkout.py
@@ -327,8 +327,11 @@ def compare(  # noqa: C901
         new.onerror = onerror
 
     for entry in failed_dirs:
-        ret.dirs_create.remove(entry)
-        del ret.changes[entry.key]
+        try:
+            ret.dirs_create.remove(entry)
+        except ValueError:
+            pass
+        ret.changes.pop(entry.key, None)
 
     ret.dirs_failed = failed_dirs
 


### PR DESCRIPTION
Currently you might run into `ERROR: unexpected error - list.remove(x): x not in list` if you are trying to checkout a broken dir (no access to .dir) when there is an old empty dir that already exists.