### PR TITLE
index: collect: use fsid if available

### DIFF
--- a/src/dvc_data/index/collect.py
+++ b/src/dvc_data/index/collect.py
@@ -91,8 +91,13 @@ def collect(  # noqa: C901
             if not data:
                 continue
 
-            # FIXME should use fsid instead of protocol
-            key = (data.fs.protocol, tokenize(data.path))
+            try:
+                fsid = data.fs.fsid
+            except (NotImplementedError, AttributeError):
+                fsid = data.fs.protocol
+
+            key = (fsid, tokenize(data.path))
+
             if key not in storage_by_fs:
                 if cache_index.has_node((*cache_key, *key)):
                     skip.add(key)


### PR DESCRIPTION
Only dvcfs implements fsid right now, but we'll be gradually adding it to other filesystems. Though important to note that for most other filesystems, the path contains some unique things like bucket name, which provide enough uniqueness in most cases.

Fixes iterative/dvc#9904