### PR TITLE
push: fix cloud versioning

### DIFF
--- a/src/dvc_data/index/checkout.py
+++ b/src/dvc_data/index/checkout.py
@@ -247,11 +247,12 @@ def _compare(  # noqa: C901
             return meta
         return (meta.isdir, meta.isexec)
 
+    kwargs.setdefault("meta_cmp_key", meta_cmp_key)
+
     for change in idiff(
         old,
         new,
         with_unchanged=relink,
-        meta_cmp_key=meta_cmp_key,
         callback=callback,
         **kwargs,
     ):


### PR DESCRIPTION
Parity with old functionality. Unfortunately using old mechanisms like `latest_only`, but that will be tweaked in the future.