### PR TITLE
benchmark: fix benchmark for reflink

### DIFF
--- a/tests/benchmarks/test_checkout.py
+++ b/tests/benchmarks/test_checkout.py
@@ -4,24 +4,39 @@ from os import fspath
 import pytest
 from dvc_objects.fs import localfs
 from dvc_objects.fs.generic import test_links as _test_links
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from dvc_data.cli import build, gentree, get_odb
 from dvc_data.hashfile.checkout import checkout
 from dvc_data.hashfile.state import State
 
 
-@pytest.mark.parametrize("link", ["reflink", "copy", "symlink", "hardlink"])
-def test_checkout(tmp_local_path, benchmark, link):
-    (tmp_local_path / ".dvc").mkdir()
+@pytest.fixture
+def repo(request, monkeypatch):
+    """Create a dvc data repo within pytest'scache directory.
+    The cache directory by default, is in the root of the repo, where reflink
+    may be supported.
+    """
+    cache = request.config.cache
+    path = cache.mkdir("dvc_data_repo")
+    with TemporaryDirectory(dir=path) as tmp_dir:
+        monkeypatch.chdir(tmp_dir)
+        path = Path(tmp_dir)
+        (path / ".dvc").mkdir()
+        yield path
 
-    fs_path = fspath(tmp_local_path / "dataset")
+
+@pytest.mark.parametrize("link", ["reflink", "copy", "symlink", "hardlink"])
+def test_checkout(repo, benchmark, link):
+    fs_path = fspath(repo / "dataset")
     odb = get_odb(type=[link])
 
     if not _test_links([link], localfs, odb.path, localfs, fs_path):
         pytest.skip(f"unsupported link type: {link}")
 
-    gentree(tmp_local_path / "dataset", 1000, "50Mb")
-    obj = build(tmp_local_path / "dataset", write=True)
+    gentree(repo / "dataset", 1000, "50Mb")
+    obj = build(repo / "dataset", write=True)
     state = odb.state
 
     def setup():
@@ -37,5 +52,6 @@ def test_checkout(tmp_local_path, benchmark, link):
         setup=setup,
         args=(fs_path, localfs, obj, odb),
         kwargs={"state": state},
-        rounds=5,
+        rounds=10,
+        warmup_rounds=2,
     )


### PR DESCRIPTION
Now we create tmpdir inside .pytest_cache directory and run the test there, same as we do in dvc-objects.
We probably should write similar tests in dvc, as most of our tests run in tmpdir which is usually tmpfs in linux.