### PR TITLE
apply: remove latest_only, remove nested progress bar

### DIFF
--- a/src/dvc_data/index/checkout.py
+++ b/src/dvc_data/index/checkout.py
@@ -338,12 +338,11 @@ def _onerror_noop(*args, **kwargs):
     pass
 
 
-def apply(  # noqa: PLR0913
+def apply(
     diff: "Diff",
     path: str,
     fs: "FileSystem",
     callback: "Callback" = DEFAULT_CALLBACK,
-    latest_only: bool = True,
     update_meta: bool = True,
     jobs: Optional[int] = None,
     storage: str = "cache",
@@ -351,17 +350,6 @@ def apply(  # noqa: PLR0913
     state: Optional["StateBase"] = None,
     links: Optional[List[str]] = None,
 ) -> None:
-    if fs.version_aware and not latest_only:
-        if callback == DEFAULT_CALLBACK:
-            cb = callback
-        else:
-            desc = f"Checking status of existing versions in '{path}'"
-            cb = TqdmCallback(desc=desc, unit="file")
-        with cb:
-            diff.files_create = list(
-                _prune_existing_versions(diff.files_create, fs, path, callback=cb)
-            )
-
     if onerror is None:
         onerror = _onerror_noop
 


### PR DESCRIPTION
Removes `latest_only` since it's only used in a single place, and it feels more like a `diff`/`compare` than `apply`. Also, makes the progress bar logic simpler and avoids nesting of the callbacks (the `apply` gets a callback for `create_files` and creates one internally for `diff`).


Note, this does hardcore `TqdmCallback` explicitly, but we were doing that before in practice already. I have some plans to get rid of this soon by introducing a callback factory for now.

Diff is messed up due to indentation. Use this link for better diff:
https://github.com/iterative/dvc-data/pull/486/files?w=1