### PR TITLE
view: run filter_fn over a key

### DIFF
--- a/src/dvc_data/index/view.py
+++ b/src/dvc_data/index/view.py
@@ -104,11 +104,9 @@ class DataIndexView(BaseDataIndex):
         ):
             self._index._load(prefix, entry)
             if not shallow:
-                yield from (
-                    (key, val)
-                    for key, val in self._index.iteritems(entry.key)
-                    if key != prefix
-                )
+                for key, val in self._index.iteritems(entry.key):
+                    if key != prefix and self.filter_fn(key):
+                        yield key, val
 
     def iteritems(
         self,


### PR DESCRIPTION
To be honest, I don't know how to write a test here (there is no test for `iteritems(prefix=)` anyway). So, any help here would be appreciated.


And I haven't been able to re-create that scenario with the test in `dvc-data`, because `DataIndexView.traverse` already filters them out. So my guess is some interaction with `filter_fn` that comes from `dvc`. 
 
Closes https://github.com/iterative/dvc/issues/10199.