### PR TITLE
hashfile: standardize azure etag format

### DIFF
--- a/src/dvc_data/hashfile/meta.py
+++ b/src/dvc_data/hashfile/meta.py
@@ -38,6 +38,8 @@ class Meta:
         etag = info.get("etag")
         checksum = info.get("checksum")
 
+        if protocol == "azure" and etag and not etag.startswith('"'):
+            etag = f'"{etag}"'
         if protocol == "s3" and "ETag" in info:
             etag = info["ETag"].strip('"')
         elif protocol == "gs" and "etag" in info:


### PR DESCRIPTION
Fixes https://github.com/iterative/dvc/issues/10271

from https://github.com/iterative/dvc/issues/10271#issuecomment-1945523951
> When using `BlobClient.get_blob_properties()` the returned etag property is enclosed in `"` quotes. However, when using `BlobContainer.walk_blobs()` the etag property for iterated blobs is not enclosed in quotes. This causes adlfs to have different behavior for the etag field when using `fs.ls(detail=True)` vs `fs.info()`.