### PR TITLE
index: skip collection for fs with invalid fsid

### DIFF
--- a/src/dvc_data/index/collect.py
+++ b/src/dvc_data/index/collect.py
@@ -71,7 +71,7 @@ def _collect_from_index(
         cache[(*cache_prefix, *key)] = entry
 
 
-def collect(  # noqa: C901, PLR0912
+def collect(  # noqa: C901, PLR0912, PLR0915
     idxs,
     storage,
     callback: "Callback" = DEFAULT_CALLBACK,
@@ -101,6 +101,12 @@ def collect(  # noqa: C901, PLR0912
                 fsid = data.fs.fsid
             except (NotImplementedError, AttributeError):
                 fsid = data.fs.protocol
+            except BaseException as exc:  # noqa: BLE001
+                logger.debug(
+                    "skipping index collection for data with invalid fsid",
+                    exc_info=exc,
+                )
+                continue
 
             key = (fsid, tokenize(data.path))
 


### PR DESCRIPTION
related: https://github.com/iterative/dvc/issues/10309

In dvcfs, trying to read `fs.fsid` forces us to load the erepo which may end up raising an SCMError in the event we cannot clone the source repo. In this case, we will not be able to collect anything from that fs, so we should just ignore trying to collect this data/storage