### PR TITLE
use functools.cached_property on >=3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,9 @@ classifiers = [
 requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
-    "funcy>=1.14",
+    "funcy>=1.14; python_version < '3.12'",
     "dictdiffer>=0.8.1",
     "pygtrie>=2.3.2",
-    "shortuuid>=0.5.0",
     "dvc-objects>=4.0.1,<6",
     "fsspec>=2024.2.0",
     "diskcache>=5.2.1",
@@ -191,8 +190,8 @@ parametrize-names-type = "csv"
 
 [tool.ruff.lint.flake8-tidy-imports]
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
-"funcy.cached_property" = {msg = "use `from dvc_data.utils import cached_property` instead."}
-"functools.cached_property" = {msg = "use `from dvc_data.utils import cached_property` instead."}
+"funcy.cached_property" = {msg = "use `from dvc_data.compat import cached_property` instead."}
+"functools.cached_property" = {msg = "use `from dvc_data.compat import cached_property` instead."}
 
 [tool.ruff.lint.flake8-type-checking]
 strict = true

--- a/src/dvc_data/compat.py
+++ b/src/dvc_data/compat.py
@@ -1,6 +1,7 @@
+import sys
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
+if sys.version_info >= (3, 12) or TYPE_CHECKING:
     from functools import cached_property  # noqa: TID251
 else:
     from funcy import cached_property  # noqa: TID251

--- a/src/dvc_data/hashfile/db/local.py
+++ b/src/dvc_data/hashfile/db/local.py
@@ -6,9 +6,8 @@ from typing import ClassVar
 
 from dvc_objects.db import noop, wrap_iter
 from dvc_objects.errors import ObjectDBError, ObjectFormatError
-from dvc_objects.fs.utils import copyfile, remove
+from dvc_objects.fs.utils import copyfile, remove, tmp_fname
 from fsspec.callbacks import DEFAULT_CALLBACK
-from shortuuid import uuid
 
 from . import HashFileDB
 
@@ -83,7 +82,7 @@ class LocalHashFileDB(HashFileDB):
     def _unprotect_file(self, path, callback=DEFAULT_CALLBACK):
         if self.fs.is_symlink(path) or self.fs.is_hardlink(path):
             logger.debug("Unprotecting '%s'", path)
-            tmp = os.path.join(os.path.dirname(path), "." + uuid())
+            tmp = os.path.join(os.path.dirname(path), tmp_fname())
 
             # The operations order is important here - if some application
             # would access the file during the process of copyfile then it

--- a/src/dvc_data/hashfile/tree.py
+++ b/src/dvc_data/hashfile/tree.py
@@ -6,10 +6,10 @@ from typing import TYPE_CHECKING, Any, Final, Optional
 
 from dvc_objects.errors import ObjectFormatError
 
+from dvc_data.compat import cached_property
 from dvc_data.hashfile.hash import DEFAULT_ALGORITHM, hash_file
 from dvc_data.hashfile.meta import Meta
 from dvc_data.hashfile.obj import HashFile
-from dvc_data.utils import cached_property
 
 if TYPE_CHECKING:
     from pygtrie import Trie

--- a/src/dvc_data/index/index.py
+++ b/src/dvc_data/index/index.py
@@ -3,26 +3,15 @@ import logging
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, MutableMapping
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Optional,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 import attrs
-from sqltrie import (
-    JSONTrie,
-    PyGTrie,
-    ShortKeyError,
-    SQLiteTrie,
-)
+from sqltrie import JSONTrie, PyGTrie, ShortKeyError, SQLiteTrie
 
+from dvc_data.compat import cached_property
 from dvc_data.hashfile.hash_info import HashInfo
 from dvc_data.hashfile.meta import Meta
 from dvc_data.hashfile.tree import Tree
-from dvc_data.utils import cached_property
 
 if TYPE_CHECKING:
     from dvc_objects.fs.base import FileSystem

--- a/tests/hashfile/test_db_index.py
+++ b/tests/hashfile/test_db_index.py
@@ -1,5 +1,4 @@
 import pytest
-from funcy import first
 
 from dvc_data.hashfile.db.index import ObjectDBIndex
 
@@ -22,7 +21,7 @@ def test_roundtrip(tmp_upath, index):
 def test_clear(index):
     index.update(["1234.dir"], ["5678"])
     index.clear()
-    assert first(index.hashes()) is None
+    assert not list(index.hashes())
 
 
 def test_update(index):


### PR DESCRIPTION
- Also removes shortuuid, and uses `tmp_fname` from `dvc_objects`. `uuid` was only used for tmp files during `unprotect`. Using `tmp_fname()` will make it consistent with other operations.

- After removing funcy.cached_property, the only use of funcy was for `split`, which has been refactored as well. So, we also don't need to depend on funcy now.

Similar to what was done in iterative/dvc-objects#269 and /iterative/dvc-objects#270.