### PR TITLE
Honor cache storage when file get pulled into cache

### DIFF
--- a/src/dvc_data/fs.py
+++ b/src/dvc_data/fs.py
@@ -206,6 +206,7 @@ class DataFileSystem(AbstractFileSystem):
         cache = kwargs.pop("cache", False)
         if cache and typ == "remote" and cache_storage:
             fs, path = self._cache_remote_file(cache_storage, fs, path, hi)
+            storage = cache_storage
 
         if (
             isinstance(storage, ObjectStorage)


### PR DESCRIPTION
This PR adds a simple fix for #512, so the cache storage configuration is honoured when pulling remote files into cache.