### PR TITLE
state/cache: implement get_many/set_many

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pygtrie>=2.3.2",
     "sqltrie>=0.11.0,<1",
     "tqdm>=4.63.1,<5",
+    "orjson>=3,<4; implementation_name=='cpython'",
 ]
 
 [project.urls]

--- a/src/dvc_data/compat.py
+++ b/src/dvc_data/compat.py
@@ -1,9 +1,23 @@
 import sys
-from typing import TYPE_CHECKING
+from collections.abc import Iterable, Iterator
+from itertools import islice
+from typing import TYPE_CHECKING, TypeVar
 
 if sys.version_info >= (3, 12) or TYPE_CHECKING:
     from functools import cached_property  # noqa: TID251
 else:
     from funcy import cached_property  # noqa: TID251
 
-__all__ = ["cached_property"]
+
+T = TypeVar("T")
+
+
+def batched(iterable: Iterable[T], n: int) -> Iterator[tuple[T, ...]]:
+    if n < 1:
+        raise ValueError("n must be at least one")
+    it = iter(iterable)
+    while batch := tuple(islice(it, n)):
+        yield batch
+
+
+__all__ = ["cached_property", "batched"]

--- a/src/dvc_data/hashfile/cache.py
+++ b/src/dvc_data/hashfile/cache.py
@@ -106,12 +106,6 @@ class HashesCache(Cache):
         ((exists,),) = res
         return exists == 0
 
-    def set(
-        self, key: str, value: str, expire=None, read=False, tag=None, retry=False
-    ) -> Literal[True]:
-        self.set_many([(key, value)], retry=retry)
-        return True
-
     def get(
         self, key, default=None, read=False, expire_time=False, tag=False, retry=False
     ):

--- a/src/dvc_data/json_compat.py
+++ b/src/dvc_data/json_compat.py
@@ -1,0 +1,22 @@
+import json
+from typing import Any
+
+try:
+    import orjson  # type: ignore[import-not-found]
+except ImportError:
+
+    def loads(data: str) -> Any:
+        return json.loads(data)
+
+    def dumps(data: Any) -> str:
+        return json.dumps(data)
+else:
+
+    def loads(data: str) -> Any:
+        return orjson.loads(data)
+
+    def dumps(data: Any) -> str:
+        return orjson.dumps(data).decode("utf8")
+
+
+__all__ = ["loads", "dumps"]

--- a/tests/hashfile/test_build.py
+++ b/tests/hashfile/test_build.py
@@ -1,0 +1,42 @@
+import os
+
+from dvc_objects.fs.local import LocalFileSystem
+
+from dvc_data.hashfile.build import build
+from dvc_data.hashfile.db import HashFileDB
+from dvc_data.hashfile.hash_info import HashInfo
+from dvc_data.hashfile.meta import Meta
+from dvc_data.hashfile.tree import Tree
+
+
+def test_build_file(tmp_path):
+    fs = LocalFileSystem()
+    file = tmp_path / "foo"
+
+    odb = HashFileDB(fs, os.fspath(tmp_path / ".dvc" / ".cache" / "files" / "md5"))
+
+    fs.pipe({file: b"foo"})
+
+    _, meta, obj = build(odb, str(file), fs, "md5")
+    assert meta.isdir is False
+    assert meta.size == 3
+    assert obj.hash_info == HashInfo("md5", "acbd18db4cc2f85cedef654fccc4a4d8")
+
+
+def test_build_directory(tmp_path):
+    fs = LocalFileSystem()
+    directory = tmp_path / "dir"
+    directory.mkdir()
+
+    odb = HashFileDB(fs, os.fspath(tmp_path / ".dvc" / ".cache" / "files" / "md5"))
+
+    fs.pipe({directory / "foo": b"foo", directory / "bar": b"bar"})
+
+    _, meta, tree = build(odb, str(directory), fs, "md5")
+    assert meta == Meta(isdir=True, size=6, nfiles=2)
+    assert isinstance(tree, Tree)
+    assert tree.hash_info == HashInfo("md5", "5ea40360f5b4ec688df672a4db9c17d1.dir")
+    assert tree.as_list() == [
+        {"md5": "37b51d194a7513e45b56f6524f2d51f2", "relpath": "bar"},
+        {"md5": "acbd18db4cc2f85cedef654fccc4a4d8", "relpath": "foo"},
+    ]

--- a/tests/hashfile/test_cache.py
+++ b/tests/hashfile/test_cache.py
@@ -74,3 +74,17 @@ def test_hashes_cache_many(tmp_path):
             ("key2", "value2"),
             ("not-existing-key", None),
         ]
+
+
+@pytest.mark.parametrize("upsert", [True, False])
+def test_hashes_cache_update(tmp_path, upsert):
+    with HashesCache(tmp_path / "test") as cache:
+        cache.SUPPORTS_UPSERT = upsert
+
+        assert cache.is_empty()
+        cache.set("key1", "value")
+        cache.set_many((("key1", "value1"), ("key2", "value2")))
+        assert list(cache.get_many(("key1", "key2"))) == [
+            ("key1", "value1"),
+            ("key2", "value2"),
+        ]

--- a/tests/hashfile/test_state.py
+++ b/tests/hashfile/test_state.py
@@ -1,0 +1,259 @@
+import os
+
+import pytest
+from dvc_objects.fs import MemoryFileSystem
+from dvc_objects.fs.local import LocalFileSystem
+from dvc_objects.fs.system import inode
+
+from dvc_data.hashfile.hash import file_md5
+from dvc_data.hashfile.hash_info import HashInfo
+from dvc_data.hashfile.meta import Meta
+from dvc_data.hashfile.state import State, StateNoop, _checksum
+from dvc_data.hashfile.utils import get_mtime_and_size
+from dvc_data.json_compat import dumps as json_dumps
+
+
+def test_hashes(tmp_path):
+    path = tmp_path / "foo"
+    path.write_text("foo content", encoding="utf-8")
+
+    fs = LocalFileSystem()
+    state = State(tmp_path, tmp_path / "tmp")
+
+    hash_info = HashInfo(name="md5", value="6dbda444875c24ec1bbdb433456be11f")
+
+    state.save(str(path), fs, hash_info)
+    assert state.hashes[str(path)] == json_dumps(
+        {
+            "version": 1,
+            "checksum": _checksum(fs.info(str(path))),
+            "size": 11,
+            "hash_info": {"md5": hash_info.value},
+        }
+    )
+    assert state.get(str(path), fs) == (Meta(size=11), hash_info)
+    assert list(state.get_many((str(path),), fs, {})) == [
+        (str(path), Meta(size=11), hash_info)
+    ]
+
+    path.write_text("foo content 1", encoding="utf-8")
+    info = fs.info(str(path))
+    hash_info = HashInfo(name="md5", value="8efcb74434c93f295375a9118292fd0c")
+    path.unlink()
+
+    state.save(str(path), fs, hash_info, info)
+    assert state.hashes[str(path)] == json_dumps(
+        {
+            "version": 1,
+            "checksum": _checksum(info),
+            "size": 13,
+            "hash_info": {"md5": hash_info.value},
+        }
+    )
+    assert state.get(str(path), fs, info) == (Meta(size=13), hash_info)
+    assert list(state.get_many((str(path),), fs, {str(path): info})) == [
+        (str(path), Meta(size=13), hash_info)
+    ]
+
+    assert state.get(str(path), fs) == (None, None)
+    assert list(state.get_many((str(path),), fs, {})) == [(str(path), None, None)]
+
+
+def test_hashes_get_not_a_local_fs(tmp_path):
+    state = State(tmp_path, tmp_path / "tmp")
+    fs = MemoryFileSystem()
+
+    assert state.get("not-existing-file", fs) == (None, None)
+    assert list(state.get_many(("not-existing-file",), fs, {})) == [
+        ("not-existing-file", None, None)
+    ]
+
+
+def test_hashes_get_invalid_data(tmp_path):
+    path = tmp_path / "foo"
+    path.write_text("foo content", encoding="utf-8")
+
+    fs = LocalFileSystem()
+    state = State(tmp_path, tmp_path / "tmp")
+
+    # invalid json
+    state.hashes[str(path)] = ""
+    assert state.get(str(path), fs) == (None, None)
+    assert list(state.get_many((str(path),), fs, {})) == [(str(path), None, None)]
+
+    # invalid json
+    state.hashes[str(path)] = '{"x"}'
+    assert state.get(str(path), fs) == (None, None)
+    assert list(state.get_many((str(path),), fs, {})) == [(str(path), None, None)]
+
+    # invalid checksum
+    state.hashes[str(path)] = json_dumps(
+        {
+            "version": 1,
+            "checksum": 1,
+            "size": 13,
+            "hash_info": {"md5": "value"},
+        }
+    )
+    assert state.get(str(path), fs) == (None, None)
+    assert list(state.get_many((str(path),), fs, {})) == [(str(path), None, None)]
+
+    # invalid version
+    state.hashes[str(path)] = json_dumps(
+        {
+            "version": state.HASH_VERSION + 1,
+            "checksum": _checksum(fs.info(str(path))),
+            "size": 13,
+            "hash_info": {"md5": "value"},
+        }
+    )
+    assert state.get(str(path), fs) == (None, None)
+    assert list(state.get_many((str(path),), fs, {})) == [(str(path), None, None)]
+
+
+def test_hashes_without_version(tmp_path):
+    # If there is no version, it is considered as old md5-dos2unix hashes.
+    # dvc-data does not write this format anymore, but it should be able to read it
+    state = State(tmp_path, tmp_path / "tmp")
+    fs = LocalFileSystem()
+
+    path = tmp_path / "foo"
+    path.write_text("foo content", encoding="utf-8")
+
+    state.hashes[str(path)] = json_dumps(
+        {
+            "checksum": _checksum(fs.info(str(path))),
+            "size": 11,
+            "hash_info": {"md5": "value"},
+        }
+    )
+    assert state.get(str(path), fs) == (
+        Meta(size=11),
+        HashInfo("md5-dos2unix", "value"),
+    )
+    assert list(state.get_many((str(path),), fs, {})) == [
+        (str(path), Meta(size=11), HashInfo("md5-dos2unix", "value"))
+    ]
+
+
+def test_hashes_save_not_existing(tmp_path):
+    state = State(tmp_path, tmp_path / "tmp")
+    fs = LocalFileSystem()
+
+    with pytest.raises(FileNotFoundError):
+        state.save("not-existing-file", fs, HashInfo("md5", "value"))
+
+    state.save_many((("not-existing-file", HashInfo("md5", "value"), None),), fs)
+    assert len(state.hashes) == 0
+
+
+def test_hashes_save_when_fs_is_not_a_local_fs(tmp_path):
+    state = State(tmp_path, tmp_path / "tmp")
+    fs = MemoryFileSystem()
+
+    state.save("not-existing-file", fs, HashInfo("md5", "value"))
+    assert len(state.hashes) == 0
+
+    state.save_many((("not-existing-file", HashInfo("md5", "value"), None),), fs)
+    assert len(state.hashes) == 0
+
+
+def test_state_many(tmp_path):
+    foo = tmp_path / "foo"
+    foo.write_text("foo content", encoding="utf-8")
+
+    bar = tmp_path / "bar"
+    bar.write_text("bar content", encoding="utf-8")
+
+    state = State(tmp_path, tmp_path / "tmp")
+    fs = LocalFileSystem()
+
+    hash_info_foo = HashInfo("md5", file_md5(foo, fs))
+    hash_info_bar = HashInfo("md5", file_md5(bar, fs))
+
+    state.save_many(
+        [(str(foo), hash_info_foo, None), (str(bar), hash_info_bar, None)], fs
+    )
+    assert list(state.get_many([str(foo), str(bar)], fs, {})) == [
+        (str(foo), Meta(size=11), hash_info_foo),
+        (str(bar), Meta(size=11), hash_info_bar),
+    ]
+
+    foo.write_text("foo content 1", encoding="utf-8")
+    foo_info = fs.info(str(foo))
+    hash_info_foo = HashInfo("md5", file_md5(foo, fs))
+    foo.unlink()
+    bar.write_text("bar content 1", encoding="utf-8")
+    bar_info = fs.info(str(bar))
+    hash_info_bar = HashInfo("md5", file_md5(bar, fs))
+    bar.unlink()
+
+    state.save_many(
+        [(str(foo), hash_info_foo, foo_info), (str(bar), hash_info_bar, bar_info)], fs
+    )
+    assert list(
+        state.get_many(
+            [str(foo), str(bar)], fs, {str(foo): foo_info, str(bar): bar_info}
+        )
+    ) == [
+        (str(foo), Meta(size=13), hash_info_foo),
+        (str(bar), Meta(size=13), hash_info_bar),
+    ]
+
+
+def test_state_noop(tmp_path):
+    state = StateNoop()
+    fs = LocalFileSystem()
+
+    state.save_many([("foo", HashInfo("md5", "value"), None)], fs)
+    assert state.get("foo", fs) == (None, None)
+    assert list(state.get_many(("foo", "bar"), fs, {})) == [
+        ("foo", None, None),
+        ("bar", None, None),
+    ]
+
+
+def test_links(tmp_path):
+    foo, bar = tmp_path / "foo", tmp_path / "bar"
+    dataset = tmp_path / "dataset"
+    dataset.mkdir()
+    file = dataset / "file"
+
+    for path in [foo, bar, file]:
+        path.write_text(f"{path.name} content", encoding="utf-8")
+
+    fs = LocalFileSystem()
+    state = State(tmp_path, tmp_path / "tmp")
+
+    state.save_link(os.fspath(foo), fs)
+    state.save_link(os.fspath(bar), fs)
+    state.save_link(os.fspath(dataset), fs)
+
+    def _get_inode_mtime(path):
+        path = os.fspath(path)
+        return inode(path), get_mtime_and_size(path, fs)[0]
+
+    assert len(state.links) == 3
+    assert {k: state.links[k] for k in state.links} == {
+        "foo": _get_inode_mtime(foo),
+        "bar": _get_inode_mtime(bar),
+        "dataset": _get_inode_mtime(dataset),
+    }
+
+    links = [os.fspath(tmp_path / link) for link in ["foo", "bar", "dataset"]]
+    assert set(state.get_unused_links([], fs)) == {"foo", "bar", "dataset"}
+    assert set(state.get_unused_links(links[:1], fs)) == {"bar", "dataset"}
+    assert set(state.get_unused_links(links[:2], fs)) == {"dataset"}
+    assert set(state.get_unused_links(links, fs)) == set()
+    assert set(
+        state.get_unused_links(
+            (links[:1] + [os.path.join(tmp_path, "not-existing-file")]),
+            fs,
+        )
+    ) == {"bar", "dataset"}
+
+    state.remove_links(["foo", "bar", "dataset"], fs)
+    assert len(state.links) == 0
+    assert not foo.exists()
+    assert not bar.exists()
+    assert not dataset.exists()


### PR DESCRIPTION
This PR implements batching `save` and `get` in `State`.

As a result of this change, `_build_tree()` is faster by 70% - 90% on the first run, and 50% faster on repeated runs with this PR. You can find the results below for the mnist dataset. 

This should dramatically improve the performance for `dvc add --no-relink`, and other places where we build trees and compute hashes. Real-world impact is mixed and depends on individual commands, but all of the commands show improvements from 4-5 % to 20%, and in some cases,  even 70% or more.

This also brings back support for `core.checksum_jobs` to concurrently hash multiple files at once.

This is done by partitioning the files to hash into two buckets: a) files that are smaller than 1MB and, b) files that are larger than 1MB. 

Files smaller than 1MB are hashed sequentially, and larger files are hashed in a ThreadPoolExecutor.

### Benchmark

### `main`

```
$ rm -rf .dvc/tmp
$ time dvc-data build dataset
object e42412b82dcab425ce9c7e2d0abdfb78.dir

________________________________________________________
Executed in   16.39 secs    fish           external
   usr time   11.18 secs    0.00 micros   11.18 secs
   sys time    3.73 secs  348.00 micros    3.73 secs

$ time dvc-data build dataset
object e42412b82dcab425ce9c7e2d0abdfb78.dir

________________________________________________________
Executed in    2.76 secs    fish           external
   usr time    2.49 secs  236.00 micros    2.49 secs
   sys time    0.22 secs   52.00 micros    0.22 secs
```

### `PR`

```
$ rm -rf .dvc/tmp
$ time dvc-data build dataset
object e42412b82dcab425ce9c7e2d0abdfb78.dir

________________________________________________________
Executed in    2.95 secs    fish           external
   usr time    2.33 secs  262.00 micros    2.33 secs
   sys time    0.36 secs   61.00 micros    0.36 secs

$  time dvc-data build dataset
object e42412b82dcab425ce9c7e2d0abdfb78.dir

________________________________________________________
Executed in    1.36 secs    fish           external
   usr time    1.20 secs  198.00 micros    1.20 secs
   sys time    0.12 secs   38.00 micros    0.12 secs
```


<details><summary>DVC-bench results on an MNIST dataset</summary>
<p>

| Test | main (in s) | PR (in s) | △ |
|--------|--------|--------|--------|
| test_add-add | 87.2241 | 62.7932 | 28% |
| test_checkout_copy-checkout | 31.0993 | 29.1070 | 6% |
| test_checkout_copy-checkout-noop | 6.5580 | 5.4686 | 16% |
| test_checkout_copy-checkout-update | 7.5199 | 6.2810 | 16% |
| test_data_status-data-new | 21.3120 | 15.9083 | 25% | 
| test_data_status-data-noop | 5.4173 | 4.1119 | 24% | 
| test_data_status-data-changed | 5.3719 | 4.1306 | 23% | 
| test_data_status-data-changed-noop | 5.3541 | 4.1927 | 21% | 
| test_diff-diff | 22.6914 | 18.3842 | 19% | 
| test_diff-diff-changed | 6.5643 | 5.3981 | 17% | 
| test_diff-diff-changed-noop | 6.5565 | 5.3985 | 17% | 
| test_diff-diff-noop | 6.6704 | 5.3392 | 20% | 
| test_import_url-import-url | 131.6878 | 87.0350 | 34% | 
| test_status-status | 20.6743 | 6.0155 | 71% | 
| test_status-status-changed | 6.0105 | 3.1429 | 48% | 
| test_update-import-url | 130.6300 | 86.5345 | 33% | 
| test_fetch-fetch | 37.0039 | 26.7890 | 27% |


See https://github.com/iterative/dvc-bench/actions/runs/10252645782.
</p>
</details> 
