### PR TITLE
replace hash with unsafe_hash

### DIFF
--- a/src/dvc_data/hashfile/diff.py
+++ b/src/dvc_data/hashfile/diff.py
@@ -16,7 +16,7 @@ DELETE = "delete"
 UNCHANGED = "unchanged"
 
 
-@define(hash=True, order=True)
+@define(unsafe_hash=True, order=True)
 class TreeEntry:
     in_cache: bool = field(default=False, eq=False)
     key: tuple[str, ...] = ()
@@ -27,7 +27,7 @@ class TreeEntry:
         return bool(self.oid)
 
 
-@define(hash=True, order=True)
+@define(unsafe_hash=True, order=True)
 class Change:
     old: TreeEntry = field(factory=TreeEntry)
     new: TreeEntry = field(factory=TreeEntry)

--- a/src/dvc_data/hashfile/hash_info.py
+++ b/src/dvc_data/hashfile/hash_info.py
@@ -5,7 +5,7 @@ from attrs import define, field
 HASH_DIR_SUFFIX = ".dir"
 
 
-@define(hash=True)
+@define(unsafe_hash=True)
 class HashInfo:
     name: Optional[str] = None
     value: Optional[str] = None

--- a/src/dvc_data/hashfile/meta.py
+++ b/src/dvc_data/hashfile/meta.py
@@ -4,7 +4,7 @@ from attrs import define, field, fields_dict
 from dvc_objects.fs.utils import is_exec
 
 
-@define(hash=True)
+@define(unsafe_hash=True)
 class Meta:
     PARAM_ISDIR: ClassVar[str] = "isdir"
     PARAM_SIZE: ClassVar[str] = "size"

--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -21,7 +21,7 @@ UNCHANGED = "unchanged"
 UNKNOWN = "unknown"
 
 
-@define(frozen=True, hash=True, order=True)
+@define(frozen=True, unsafe_hash=True, order=True)
 class Change:
     typ: str
     old: Optional[DataIndexEntry]

--- a/src/dvc_data/index/index.py
+++ b/src/dvc_data/index/index.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 DataIndexKey = tuple[str, ...]
 
 
-@attrs.define(hash=True)
+@attrs.define(unsafe_hash=True)
 class DataIndexEntry:
     key: Optional[DataIndexKey] = None
     meta: Optional["Meta"] = None


### PR DESCRIPTION
It was added in attrs==22.2.0, and is an alias to `hash`. The `hash` is now deprecated since the latest release 24.1.0.