### PR TITLE
check link target exists

### DIFF
--- a/src/dvc_data/hashfile/checkout.py
+++ b/src/dvc_data/hashfile/checkout.py
@@ -160,6 +160,8 @@ class Link:
     def __call__(self, cache, from_path, to_fs, to_path):
         if to_fs.exists(to_path):
             to_fs.remove(to_path)  # broken symlink
+        if not cache.fs.exists(from_path):
+            raise CheckoutError([from_path])
 
         parent = to_fs.parent(to_path)
         to_fs.makedirs(parent)


### PR DESCRIPTION
Closes https://github.com/iterative/dvc/issues/10500. Open to other ideas for how to solve it, but right now linking to a nonexistent target raises no error and can cause downstream problems like in that issue.