### PR TITLE
diff: do not recurse when trying to get stats

### DIFF
--- a/src/dvc_data/hashfile/diff.py
+++ b/src/dvc_data/hashfile/diff.py
@@ -65,7 +65,11 @@ class DiffResult:
 
     @property
     def stats(self) -> dict[str, int]:
-        return {k: len(v) for k, v in asdict(self).items() if k != "unchanged"}
+        return {
+            k: len(v)
+            for k, v in asdict(self, recurse=False).items()
+            if k != "unchanged"
+        }
 
 
 ROOT = ("",)


### PR DESCRIPTION
Saves about 12 seconds on `dvc add` for an MNIST dataset during checkout.