### PR TITLE
Performance(diff): faster rename detection

### DIFF
--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -1,6 +1,6 @@
+import itertools
 from collections import defaultdict, deque
 from collections.abc import Iterable
-import itertools
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from attrs import define

--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -261,13 +261,15 @@ def _detect_renames(changes: Iterable[Change]):
     # Sort the lists to maintain the same order
     # as older implementation.
     added.sort(key=_get_key)
-    deleted.sort(key=_get_key, reverse=True)
+    deleted.sort(key=_get_key)
 
     # Create a dictionary for fast lookup of deletions by hash_info
-    deleted_dict = defaultdict(list)
+    deleted_dict = defaultdict(deque)
     for change in deleted:
         # We checked change.old for all deleted above, so cast
-        deleted_dict[cast(DataIndexEntry, change.old).hash_info].append(change)
+        change_hash = cast(DataIndexEntry, change.old).hash_info
+        # appendleft to get queue behaviour (we pop off right)
+        deleted_dict[change_hash].appendleft(change)
 
     for change in added:
         # We checked change.new for all new above, so cast

--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -256,8 +256,6 @@ def _detect_renames(changes: Iterable[Change]):
     def _get_key(change):
         return change.key
 
-    # Sort the lists to maintain the same order
-    # as older implementation.
     added.sort(key=_get_key)
     deleted.sort(key=_get_key)
 

--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -263,13 +263,13 @@ def _detect_renames(changes: Iterable[Change]):
 
     # Create a dictionary for fast lookup of deletions by hash_info
     deleted_dict: dict[Optional[HashInfo], deque[Change]] = defaultdict(deque)
-    for change in deleted:
-        change_hash = change.old.hash_info if change.old else None
+    for deletion in deleted:
+        change_hash = deletion.old.hash_info if deletion.old else None
         # appendleft to get queue behaviour (we pop off right)
-        deleted_dict[change_hash].appendleft(change)
+        deleted_dict[change_hash].appendleft(deletion)
 
-    for change in added:
-        new_hash_info = change.new.hash_info if change.new else None
+    for addition in added:
+        new_hash_info = addition.new.hash_info if addition.new else None
 
         # If the new entry is the same as a deleted change,
         # it is in fact a rename.
@@ -281,10 +281,10 @@ def _detect_renames(changes: Iterable[Change]):
             yield Change(
                 RENAME,
                 deletion.old,
-                change.new,
+                addition.new,
             )
         else:
-            yield change
+            yield addition
 
     # Yield the remaining unmatched deletions
     if deleted_dict:

--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -264,7 +264,7 @@ def _detect_renames(changes: Iterable[Change]):
     deleted.sort(key=_get_key)
 
     # Create a dictionary for fast lookup of deletions by hash_info
-    deleted_dict: dict[HashInfo | None, deque[Change]] = defaultdict(deque)
+    deleted_dict: dict[Optional[HashInfo], deque[Change]] = defaultdict(deque)
     for change in deleted:
         # We checked change.old for all deleted above, so cast
         change_hash = cast(DataIndexEntry, change.old).hash_info

--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -1,7 +1,7 @@
 import itertools
 from collections import defaultdict, deque
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Callable, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from attrs import define
 from fsspec.callbacks import DEFAULT_CALLBACK, Callback

--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -264,7 +264,7 @@ def _detect_renames(changes: Iterable[Change]):
     deleted.sort(key=_get_key)
 
     # Create a dictionary for fast lookup of deletions by hash_info
-    deleted_dict = defaultdict(deque)
+    deleted_dict: dict[HashInfo | None, deque[Change]] = defaultdict(deque)
     for change in deleted:
         # We checked change.old for all deleted above, so cast
         change_hash = cast(DataIndexEntry, change.old).hash_info

--- a/src/dvc_data/index/diff.py
+++ b/src/dvc_data/index/diff.py
@@ -240,6 +240,7 @@ def _diff(  # noqa: C901
 
             yield Change(typ, old_entry, new_entry)
 
+
 def _detect_renames(changes: Iterable[Change]):
     added = []
     deleted = []
@@ -257,7 +258,6 @@ def _detect_renames(changes: Iterable[Change]):
 
     added.sort(key=_get_key)
     deleted.sort(key=_get_key, reverse=True)
-
 
     # Create a dictionary for fast lookup of deletions by hash_info
     deleted_dict = defaultdict(list)

--- a/tests/index/test_diff.py
+++ b/tests/index/test_diff.py
@@ -60,43 +60,6 @@ def test_diff():
     }
 
 
-def test_diff_non_unique_hash():
-    """Test renaming behavior when multiple entries share the same hash."""
-
-    def create_entry(key):
-        return DataIndexEntry(
-            key=key,
-            meta=Meta(),
-            hash_info=HashInfo(name="md5", value="d3b07384d113edec49eaa6238ad5ff00"),
-        )
-
-    initial_entries = [create_entry(("foo",)), create_entry(("bar",))]
-    intermediate_entries = [create_entry(("foo.txt",)), create_entry(("bar",))]
-    final_entries = [create_entry(("foo.txt",)), create_entry(("zab", "bar"))]
-
-    initial = DataIndex({entry.key: entry for entry in initial_entries})
-    intermediate = DataIndex({entry.key: entry for entry in intermediate_entries})
-    final = DataIndex({entry.key: entry for entry in final_entries})
-
-    expected_initial_intermediate_diff = {
-        Change(RENAME, initial[("foo",)], intermediate[("foo.txt",)]),
-        Change(UNCHANGED, initial[("bar",)], initial[("bar",)]),
-    }
-    expected_initial_final_diff = {
-        Change(RENAME, initial[("foo",)], final[("zab", "bar")]),
-        Change(RENAME, initial[("bar",)], final[("foo.txt",)]),
-    }
-
-    assert (
-        set(diff(initial, intermediate, with_renames=True, with_unchanged=True))
-        == expected_initial_intermediate_diff
-    )
-    assert (
-        set(diff(initial, final, with_renames=True, with_unchanged=True))
-        == expected_initial_final_diff
-    )
-
-
 def test_diff_no_hashes():
     index = DataIndex(
         {

--- a/tests/index/test_diff.py
+++ b/tests/index/test_diff.py
@@ -70,44 +70,32 @@ def test_diff_non_unique_hash():
         )
 
     old_foo_entry = entry(("foo",))
-    old_bar_entry = entry(("bar",))
-    old_baz_entry = entry(("baz",))
     old = DataIndex({
         ("foo",): old_foo_entry,
-        ("bar",): old_bar_entry,
-        ("baz",): old_baz_entry,
     })
 
     assert set(diff(old, old, with_unchanged=True)) == {
         Change(UNCHANGED, old_foo_entry, old_foo_entry),
-        Change(UNCHANGED, old_bar_entry, old_bar_entry),
-        Change(UNCHANGED, old_baz_entry, old_baz_entry),
     }
     assert set(diff(old, old, with_renames=True, with_unchanged=True)) == {
         Change(UNCHANGED, old_foo_entry, old_foo_entry),
-        Change(UNCHANGED, old_bar_entry, old_bar_entry),
-        Change(UNCHANGED, old_baz_entry, old_baz_entry),
     }
 
-    new_foo_entry = entry(("my","new", "foo",))
-    new_bar_entry = entry(("new", "bar",))
+    new_foo_1 = entry(("a/foo.txt",))
+    new_foo_2 = entry(("foo.md",))
     new = DataIndex({
-        ("my", "new", "foo",): new_foo_entry,
-        ("new", "bar",): new_bar_entry,
-        ("baz",): old_baz_entry,
+        new_foo_1.key: new_foo_1,
+        new_foo_2.key: new_foo_2,
     })
 
     assert set(diff(old, new, with_unchanged=True)) == {
-        Change(ADD, None, new_foo_entry),
+        Change(ADD, None, new_foo_1),
+        Change(ADD, None, new_foo_2),
         Change(DELETE, old_foo_entry, None),
-        Change(ADD, None, new_bar_entry),
-        Change(DELETE, old_bar_entry, None),
-        Change(UNCHANGED, old_baz_entry, old_baz_entry),
     }
     assert set(diff(old, new, with_renames=True, with_unchanged=True)) == {
-        Change(RENAME, old_foo_entry, new_foo_entry),
-        Change(RENAME, old_bar_entry, new_bar_entry),
-        Change(UNCHANGED, old_baz_entry, old_baz_entry),
+        Change(RENAME, old_foo_entry, new_foo_1),
+        Change(ADD, None, new_foo_2),
     }
 
 

--- a/tests/index/test_diff.py
+++ b/tests/index/test_diff.py
@@ -60,6 +60,57 @@ def test_diff():
     }
 
 
+def test_diff_non_unique_hash():
+    """Test rename when multiple entries share the same hash."""
+    def entry(key):
+        return DataIndexEntry(
+            key=key,
+            meta=Meta(),
+            hash_info=HashInfo(name="md5", value="d3b07384d113edec49eaa6238ad5ff00"),
+        )
+
+    old_foo_entry = entry(("foo",))
+    old_bar_entry = entry(("bar",))
+    old_baz_entry = entry(("baz",))
+    old = DataIndex({
+        ("foo",): old_foo_entry,
+        ("bar",): old_bar_entry,
+        ("baz",): old_baz_entry,
+    })
+
+    assert set(diff(old, old, with_unchanged=True)) == {
+        Change(UNCHANGED, old_foo_entry, old_foo_entry),
+        Change(UNCHANGED, old_bar_entry, old_bar_entry),
+        Change(UNCHANGED, old_baz_entry, old_baz_entry),
+    }
+    assert set(diff(old, old, with_renames=True, with_unchanged=True)) == {
+        Change(UNCHANGED, old_foo_entry, old_foo_entry),
+        Change(UNCHANGED, old_bar_entry, old_bar_entry),
+        Change(UNCHANGED, old_baz_entry, old_baz_entry),
+    }
+
+    new_foo_entry = entry(("my","new", "foo",))
+    new_bar_entry = entry(("new", "bar",))
+    new = DataIndex({
+        ("my", "new", "foo",): new_foo_entry,
+        ("new", "bar",): new_bar_entry,
+        ("baz",): old_baz_entry,
+    })
+
+    assert set(diff(old, new, with_unchanged=True)) == {
+        Change(ADD, None, new_foo_entry),
+        Change(DELETE, old_foo_entry, None),
+        Change(ADD, None, new_bar_entry),
+        Change(DELETE, old_bar_entry, None),
+        Change(UNCHANGED, old_baz_entry, old_baz_entry),
+    }
+    assert set(diff(old, new, with_renames=True, with_unchanged=True)) == {
+        Change(RENAME, old_foo_entry, new_foo_entry),
+        Change(RENAME, old_bar_entry, new_bar_entry),
+        Change(UNCHANGED, old_baz_entry, old_baz_entry),
+    }
+
+
 def test_diff_no_hashes():
     index = DataIndex(
         {

--- a/tests/index/test_diff.py
+++ b/tests/index/test_diff.py
@@ -83,8 +83,8 @@ def test_diff_non_unique_hash():
         Change(UNCHANGED, initial[("bar",)], initial[("bar",)]),
     }
     expected_initial_final_diff = {
-        Change(RENAME, initial[("foo",)], final[("foo.txt",)]),
-        Change(RENAME, initial[("bar",)], final[("zab", "bar")]),
+        Change(RENAME, initial[("foo",)], final[("zab", "bar")]),
+        Change(RENAME, initial[("bar",)], final[("foo.txt",)]),
     }
 
     assert (

--- a/tests/index/test_diff.py
+++ b/tests/index/test_diff.py
@@ -70,32 +70,37 @@ def test_diff_non_unique_hash():
         )
 
     old_foo_entry = entry(("foo",))
+    old_bar_entry = entry(("bar",))
     old = DataIndex({
-        ("foo",): old_foo_entry,
+        old_foo_entry.key: old_foo_entry,
+        old_bar_entry.key: old_bar_entry,
     })
 
     assert set(diff(old, old, with_unchanged=True)) == {
         Change(UNCHANGED, old_foo_entry, old_foo_entry),
+        Change(UNCHANGED, old_bar_entry, old_bar_entry),
     }
     assert set(diff(old, old, with_renames=True, with_unchanged=True)) == {
         Change(UNCHANGED, old_foo_entry, old_foo_entry),
+        Change(UNCHANGED, old_bar_entry, old_bar_entry),
     }
 
-    new_foo_1 = entry(("a/foo.txt",))
-    new_foo_2 = entry(("foo.md",))
+    new_foo_entry = entry(("foo.txt",))
+    new_bar_entry = entry(("zab", "bar",))
     new = DataIndex({
-        new_foo_1.key: new_foo_1,
-        new_foo_2.key: new_foo_2,
+        new_foo_entry.key: new_foo_entry,
+        new_bar_entry.key: new_bar_entry,
     })
 
     assert set(diff(old, new, with_unchanged=True)) == {
-        Change(ADD, None, new_foo_1),
-        Change(ADD, None, new_foo_2),
+        Change(ADD, None, new_foo_entry),
+        Change(ADD, None, new_bar_entry),
         Change(DELETE, old_foo_entry, None),
+        Change(DELETE, old_bar_entry, None),
     }
     assert set(diff(old, new, with_renames=True, with_unchanged=True)) == {
-        Change(RENAME, old_foo_entry, new_foo_1),
-        Change(ADD, None, new_foo_2),
+        Change(RENAME, old_foo_entry, new_foo_entry),
+        Change(RENAME, old_bar_entry, new_bar_entry),
     }
 
 


### PR DESCRIPTION
Fixes iterative/dvc#10515

## Notes and questions
- I presume the reason for sorting `added` and `deleted` before was to optimize the runtime (more likely to get an early hit in the inner loop). I included this now maintain the former output. In the case of multiple files with the same hash, changing this may result in other pairs being detected as renames. However, if maintaining this is not a priority, I think we can remove it, making it simpler. It will still be deterministic.
- I used asserts for verifying `change.new` and `change.old`, as this seemed to be the convention. LMK. if I should change for exceptions, or if we should just assume `_diff` to always supply valid changes.
- I'm only just aware of the https://github.com/iterative/dvc-bench repo. Should we add a test case to it that would have uncovered iterative/dvc#10515?
- It is not entirely clear to me why `HashInfo` has `unsafe_hash=True`, however, as far as I understant, it should not affect this implementation.

## Benchmark

Consider a similar setup as the minimal reproduction in iterative/dvc#10515.
We make three versions of our dataset:
- **Tag1**: `mkdir data; for i in {1..10000}; do echo $i > data/file_$i; done`
- **Tag2**: `mkdir data; for i in {1..10000}; do echo $i > data/file_$i.ext; done`
- **Tag3**: `mkdir data; for i in {1..10000}; do echo $((i + 20000)) > data/file_$i.ext; done`
From Tag1 -> Tag2, we rename the files, without changing the content. From Tag2-> Tag3, we change the content of the files. 

Run `dvc diff <from> <to>`.

| Change | Old | New |
| --- | --- | --- |
| Tag1 -> Tag2 | 0.49 s | 0.50 s | 
| Tag2 -> Tag3 | 0.46 s |  0.46 s |
| Tag1 -> Tag3 | 14.6 s | 0.56 s |

Ps. Results show timings from only one experiment.